### PR TITLE
rework pkg/compare

### DIFF
--- a/pkg/compare/delta.go
+++ b/pkg/compare/delta.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare
+
+// Delta represents differences between two AWSResources. The
+// underlying types of the two supplied AWSResources should be the same. In
+// other words, the Delta() method should be called with the same concrete
+// implementing AWSResource type
+type Delta struct {
+	// Differences is a slice of *ackcompare.Difference structs representing
+	// differences in values of two resources under comparison
+	Differences []*Difference
+}
+
+// DifferentAt returns whether there is a difference at the supplied JSONPath
+// expression in the resources under comparison
+func (d *Delta) DifferentAt(subject string) bool {
+	for _, diff := range d.Differences {
+		if diff.Path.Contains(subject) {
+			return true
+		}
+	}
+	return false
+}
+
+// Add adds a new Difference to the Delta
+func (d *Delta) Add(
+	path string,
+	a interface{},
+	b interface{},
+) {
+	d.Differences = append(
+		d.Differences,
+		&Difference{NewPath(path), a, b},
+	)
+}
+
+// NewDelta returns a new Delta struct used to compare two resources.
+func NewDelta() *Delta {
+	return &Delta{
+		Differences: []*Difference{},
+	}
+}

--- a/pkg/compare/delta_test.go
+++ b/pkg/compare/delta_test.go
@@ -1,0 +1,63 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+type Foo struct {
+	Bar string
+	Baz Baz
+}
+
+type Baz struct {
+	Y string
+}
+
+func TestDifferentAt(t *testing.T) {
+	require := require.New(t)
+
+	a := Foo{
+		Bar: "a_bar",
+		Baz: Baz{
+			Y: "a_baz_y",
+		},
+	}
+	b := Foo{
+		Bar: "b_bar",
+		Baz: Baz{
+			Y: "b_baz_y",
+		},
+	}
+
+	d := compare.NewDelta()
+	d.Add("", a, nil)
+	require.True(d.DifferentAt(""))
+
+	d = compare.NewDelta()
+	d.Add("Bar", a.Bar, b.Bar)
+	require.True(d.DifferentAt("Bar"))
+	require.False(d.DifferentAt("Baz"))
+
+	d = compare.NewDelta()
+	d.Add("Baz.Y", a.Baz.Y, b.Baz.Y)
+	require.True(d.DifferentAt("Baz"))
+	require.True(d.DifferentAt("Y"))
+	require.False(d.DifferentAt("Bar"))
+}

--- a/pkg/compare/difference.go
+++ b/pkg/compare/difference.go
@@ -11,26 +11,16 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package util
+package compare
 
-// InStrings returns true if the subject string is contained in the supplied
-// slice of strings
-func InStrings(subject string, collection []string) bool {
-	for _, item := range collection {
-		if subject == item {
-			return true
-		}
-	}
-	return false
-}
-
-// InStringPs returns true if the subject string is contained in the supplied
-// slice of string pointers
-func InStringPs(subject string, collection []*string) bool {
-	for _, item := range collection {
-		if subject == *item {
-			return true
-		}
-	}
-	return false
+// Difference contains the difference in values for a specified field path into
+// two compared resources.
+type Difference struct {
+	// Path is the field path to the detected difference between resources
+	// under comparison
+	Path Path
+	// A is the value of the first resource under comparison at the Path
+	A interface{}
+	// B is the value of the first resource under comparison at the Path
+	B interface{}
 }

--- a/pkg/compare/map.go
+++ b/pkg/compare/map.go
@@ -11,26 +11,17 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package util
+package compare
 
-// InStrings returns true if the subject string is contained in the supplied
-// slice of strings
-func InStrings(subject string, collection []string) bool {
-	for _, item := range collection {
-		if subject == item {
-			return true
+// MapStringStringPEqual returns true if the supplied maps are equal
+func MapStringStringPEqual(a, b map[string]*string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for aKey, aVal := range a {
+		if bVal, ok := b[aKey]; !ok || *bVal != *aVal {
+			return false
 		}
 	}
-	return false
-}
-
-// InStringPs returns true if the subject string is contained in the supplied
-// slice of string pointers
-func InStringPs(subject string, collection []*string) bool {
-	for _, item := range collection {
-		if subject == *item {
-			return true
-		}
-	}
-	return false
+	return true
 }

--- a/pkg/compare/map_test.go
+++ b/pkg/compare/map_test.go
@@ -1,0 +1,57 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+func TestMapStringStringPEqual(t *testing.T) {
+	require := require.New(t)
+
+	aStr := "a"
+	bStr := "b"
+
+	empty := map[string]*string{}
+	a := map[string]*string{
+		"a": &aStr,
+	}
+	ac := map[string]*string{
+		"a": &aStr,
+	}
+	b := map[string]*string{
+		"b": &bStr,
+	}
+	ab := map[string]*string{
+		"a": &aStr, "b": &bStr,
+	}
+	abc := map[string]*string{
+		"a": &aStr, "b": &bStr,
+	}
+	ba := map[string]*string{
+		"b": &bStr, "a": &aStr,
+	}
+
+	require.False(compare.MapStringStringPEqual(a, empty))
+	require.False(compare.MapStringStringPEqual(empty, a))
+	require.False(compare.MapStringStringPEqual(a, b))
+	require.False(compare.MapStringStringPEqual(b, a))
+	require.True(compare.MapStringStringPEqual(a, ac))
+	require.True(compare.MapStringStringPEqual(ab, ba))
+	require.True(compare.MapStringStringPEqual(ab, abc))
+}

--- a/pkg/compare/nil.go
+++ b/pkg/compare/nil.go
@@ -11,24 +11,13 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package util
+package compare
 
-// InStrings returns true if the subject string is contained in the supplied
-// slice of strings
-func InStrings(subject string, collection []string) bool {
-	for _, item := range collection {
-		if subject == item {
-			return true
-		}
-	}
-	return false
-}
-
-// InStringPs returns true if the subject string is contained in the supplied
-// slice of string pointers
-func InStringPs(subject string, collection []*string) bool {
-	for _, item := range collection {
-		if subject == *item {
+// HasNilDifference returns true if the supplied subjects' nilness is
+// different
+func HasNilDifference(a, b interface{}) bool {
+	if a == nil || b == nil {
+		if (a == nil && b != nil) || (a != nil && b == nil) {
 			return true
 		}
 	}

--- a/pkg/compare/path.go
+++ b/pkg/compare/path.go
@@ -1,0 +1,50 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare
+
+import "strings"
+
+// Path provides a JSONPath-like struct and field-member "route" to a
+// particular field within a compared struct
+type Path struct {
+	parts []string
+}
+
+// Push adds a new part to the Path.
+func (p Path) Push(part string) {
+	p.parts = append(p.parts, part)
+}
+
+// Pop removes the last part from the Path
+func (p Path) Pop() {
+	if len(p.parts) > 0 {
+		p.parts = p.parts[:len(p.parts)-1]
+	}
+}
+
+// Contains returns true if the supplied string appears within the Path
+func (p Path) Contains(subject string) bool {
+	for _, p := range p.parts {
+		if p == subject {
+			return true
+		}
+	}
+	return false
+}
+
+// NewPath returns a new Path struct pointer from a dotted-notation string,
+// e.g. "Author.Name"
+func NewPath(dotted string) Path {
+	return Path{strings.Split(dotted, ".")}
+}

--- a/pkg/compare/slice.go
+++ b/pkg/compare/slice.go
@@ -11,26 +11,29 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package util
+package compare
 
-// InStrings returns true if the subject string is contained in the supplied
-// slice of strings
-func InStrings(subject string, collection []string) bool {
-	for _, item := range collection {
-		if subject == item {
-			return true
+import "sort"
+
+// SliceStringPEqual returns true if the supplied slices of string pointers
+// have equal values regardless of order.
+func SliceStringPEqual(a, b []*string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sa := make([]string, len(a))
+	sb := make([]string, len(a))
+	for x, aPtr := range a {
+		sa[x] = *aPtr
+		sb[x] = *b[x]
+	}
+	sort.Strings(sa)
+	sort.Strings(sb)
+	for x, aVal := range sa {
+		bVal := sb[x]
+		if aVal != bVal {
+			return false
 		}
 	}
-	return false
-}
-
-// InStringPs returns true if the subject string is contained in the supplied
-// slice of string pointers
-func InStringPs(subject string, collection []*string) bool {
-	for _, item := range collection {
-		if subject == *item {
-			return true
-		}
-	}
-	return false
+	return true
 }

--- a/pkg/compare/slice_test.go
+++ b/pkg/compare/slice_test.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+func TestSliceStringPEqual(t *testing.T) {
+	require := require.New(t)
+
+	aStr := "a"
+	bStr := "b"
+
+	empty := []*string{}
+	a := []*string{
+		&aStr,
+	}
+	ac := []*string{
+		&aStr,
+	}
+	b := []*string{
+		&bStr,
+	}
+	ab := []*string{
+		&aStr, &bStr,
+	}
+	abc := []*string{
+		&aStr, &bStr,
+	}
+	ba := []*string{
+		&bStr, &aStr,
+	}
+	aab := []*string{
+		&aStr, &aStr, &bStr,
+	}
+	aba := []*string{
+		&aStr, &bStr, &aStr,
+	}
+	bba := []*string{
+		&bStr, &bStr, &aStr,
+	}
+
+	require.False(compare.SliceStringPEqual(a, empty))
+	require.False(compare.SliceStringPEqual(empty, a))
+	require.False(compare.SliceStringPEqual(a, b))
+	require.False(compare.SliceStringPEqual(b, a))
+	require.True(compare.SliceStringPEqual(a, ac))
+	require.True(compare.SliceStringPEqual(ab, ba))
+	require.True(compare.SliceStringPEqual(ab, abc))
+	require.True(compare.SliceStringPEqual(aab, aba))
+	require.False(compare.SliceStringPEqual(aab, bba))
+}


### PR DESCRIPTION
There are three primary issues with the `google/go-cmp` package that
currently makes up the implementation of `pkg/compare` in ACK:

First, the google/go-cmp package contains the following warning in its
documentation:

> It is intended to only be used in tests, as performance is not a goal
> and it may panic if it cannot compare the values. Its propensity
> towards panicking means that its unsuitable for production environments
> where a spurious panic may be fatal.

Secondly, `go-cmp` has an awkward (IMHO) interface for setting up custom
comparison logic, relying on a Reporter interface that is neither
intuitive or extensible.

Finally, because `go-cmp` must deal with unknown data types in its
comparison implementation, it necessarily needs to use the `reflect` Go
package. This package suffers from a similarly non-intuitive and
unreadable interface (pun intended) for type inspection. However,
because ACK constructs its service controllers from API model files that
include field type information, there is no need to have runtime type
inspection like `reflect` and `go-cmp`. Instead, we can read the API
model files for the aws-sdk-go module for the service API in question
and generate Go code that uses concrete type comparison logic.

This patch lays the groundwork for swapping out our mechanisms in the
reconciler for comparing resources.

We replace the use of `google/go-cmp` in `pkg/compare` with a more
intuitive interface for processing and identifying differences between
two CRs under comparison. There is an `ackcompare.Delta` struct that has
two methods `Add` and `DifferentAt`. `ackcompare.Delta.Add` is used to
append a difference between two resources at a particular field path to
the `Delta` struct. `DifferentAt` returns whether the resources under
comparison at a specified fieldPath are different.