### PR TITLE
remove reference to old ack repository from go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/aws-controllers-k8s/runtime
 go 1.14
 
 require (
-	github.com/aws/aws-controllers-k8s v0.0.2
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.1


### PR DESCRIPTION
Issue #, if available:

`go.mod` file contains reference to old repository: `github.com/aws/aws-controllers-k8s v0.0.2`

Description of changes:

Removed the old repository reference from `go.mod` file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.