### PR TITLE
Allow optional endpoint argument

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -143,7 +143,7 @@ func (r *reconciler) reconcile(req ctrlrt.Request) error {
 	region := r.getRegion(res)
 	roleARN := r.getRoleARN(acctID)
 	sess, err := r.sc.newSession(
-		region, roleARN,
+		region, &r.cfg.EndpointURL, roleARN,
 		res.RuntimeObject().GetObjectKind().GroupVersionKind(),
 	)
 	if err != nil {

--- a/pkg/runtime/session.go
+++ b/pkg/runtime/session.go
@@ -34,6 +34,7 @@ const appName = "aws-controller-k8s"
 // the session.
 func (c *ServiceController) newSession(
 	region ackv1alpha1.AWSRegion,
+	endpointURL *string,
 	assumeRoleARN ackv1alpha1.AWSResourceName,
 	groupVersionKind schema.GroupVersionKind,
 ) (*session.Session, error) {
@@ -41,6 +42,10 @@ func (c *ServiceController) newSession(
 		Region:              aws.String(string(region)),
 		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 	}
+	if endpointURL != nil {
+		awsCfg.Endpoint = endpointURL
+	}
+
 	sess, err := session.NewSession(&awsCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Most AWS including ElastiCache allows customers to invoke APIs using FIPS
endpoint.

https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints

This commit introduces ability to specify endpoint URL like AWS CLI.