### PR TITLE
adopt only if APIGroup match

### DIFF
--- a/pkg/runtime/log/resource.go
+++ b/pkg/runtime/log/resource.go
@@ -16,6 +16,7 @@ package log
 import (
 	"github.com/go-logr/logr"
 
+	"github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
@@ -66,4 +67,51 @@ func InfoResource(
 	additionalValues ...interface{},
 ) {
 	AdaptResource(log, res, additionalValues...).V(0).Info(msg)
+}
+
+// AdaptAdoptedResource returns a logger with log values set for the adopted
+// resource's kind, namespace, name, etc
+func AdaptAdoptedResource(
+	log logr.Logger,
+	res *v1alpha1.AdoptedResource,
+	additionalValues ...interface{},
+) logr.Logger {
+	ns := res.Namespace
+	resName := res.Name
+	generation := res.Generation
+	group := res.Spec.Kubernetes.Group
+	kind := res.Spec.Kubernetes.Kind
+	vals := []interface{}{
+		"target_group", group,
+		"target_kind", kind,
+		"namespace", ns,
+		"name", resName,
+		"generation", generation,
+	}
+	if len(additionalValues) > 0 {
+		vals = append(vals, additionalValues...)
+	}
+	return log.WithValues(vals...)
+}
+
+// DebugAdoptedResource writes a supplied log message about a adopted resource that
+// includes a set of standard log values for the resource's kind, namespace, name, etc
+func DebugAdoptedResource(
+	log logr.Logger,
+	res *v1alpha1.AdoptedResource,
+	msg string,
+	additionalValues ...interface{},
+) {
+	AdaptAdoptedResource(log, res, additionalValues...).V(1).Info(msg)
+}
+
+// InfoAdoptedResource writes a supplied log message about a adopted resource that
+// includes a set of standard log values for the resource's kind, namespace, name, etc
+func InfoAdoptedResource(
+	log logr.Logger,
+	res *v1alpha1.AdoptedResource,
+	msg string,
+	additionalValues ...interface{},
+) {
+	AdaptAdoptedResource(log, res, additionalValues...).V(0).Info(msg)
 }


### PR DESCRIPTION
**Return early if the API group for target resource does not match the controller where adopted reconciler is running in**. This will help solve two issues:
  1. Mutiple controller scenario(different services), resource status always set to `ACK.Adopted = False` because multiple controller try to update the Status(backoff and retry) and only one can succeed
  2. If user tries to adopt a resourceKind which is not supported in the controller or they has a typo in Kind, they will see an error

PR does not solve the following issue:
- If user makes an error in APIGroup(does not match any controller), all controllers will go to no-op. None will status populate status/error

-----

**Enchance logging in adoption resource reconciler**

Previously
- Log did not have any information about which resource it was reconciling for
```
2021-05-07T17:23:04.146Z	INFO	ackrt	starting adoption reconciliation
```
With this PR (intentionally added a new line below, not in code)
```
2021-05-07T22:33:45.037Z	INFO	ackrt
starting adoption reconciliation	{"kind": "AdoptedResource", "namespace": "default", "name": "m-ep-2", "generation": 1}
```

https://github.com/aws-controllers-k8s/community/issues/755