### PR TITLE
Correctly validate the nil check for interfaces.

### DIFF
--- a/pkg/compare/nil.go
+++ b/pkg/compare/nil.go
@@ -13,13 +13,37 @@
 
 package compare
 
+import (
+	"reflect"
+)
+
 // HasNilDifference returns true if the supplied subjects' nilness is
 // different
 func HasNilDifference(a, b interface{}) bool {
-	if a == nil || b == nil {
-		if (a == nil && b != nil) || (a != nil && b == nil) {
+	if isNil(a) || isNil(b) {
+		if (isNil(a) && isNotNil(b)) || (isNil(b) && isNotNil(a)) {
 			return true
 		}
 	}
 	return false
+}
+
+// isNil checks the passed interface argument for Nil value.
+// For interfaces, only 'i==nil' check is not sufficient.
+// https://tour.golang.org/methods/12
+// More details: https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
+func isNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		return reflect.ValueOf(i).IsNil()
+	}
+	return false
+}
+
+func isNotNil(i interface{}) bool {
+	return !isNil(i)
 }

--- a/pkg/compare/nil_test.go
+++ b/pkg/compare/nil_test.go
@@ -1,0 +1,46 @@
+package compare_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+func TestNilDifference(t *testing.T) {
+	require := require.New(t)
+
+	sampleString := ""
+	var nullPtr *string
+	nonNullPtr := &sampleString
+	var nullMap map[string]string
+	nonNullMap := make(map[string]string)
+	var nullArray []string
+	nonNullArray := make([]string, 0)
+	var nullChan chan int
+	nonNullChan := make(chan int, 0)
+
+	require.False(compare.HasNilDifference(nil, nil))
+	require.False(compare.HasNilDifference("a", "b"))
+	require.True(compare.HasNilDifference(nil, "b"))
+	require.True(compare.HasNilDifference("a", nil))
+
+	//Pointer
+	require.False(compare.HasNilDifference(nullPtr, nil))
+	require.True(compare.HasNilDifference(nullPtr, nonNullPtr))
+
+	//Map
+	require.False(compare.HasNilDifference(nullMap, nil))
+	require.True(compare.HasNilDifference(nullMap, nonNullMap))
+
+	//Array or Slice
+	require.False(compare.HasNilDifference(nullArray, nil))
+	require.True(compare.HasNilDifference(nullArray, nonNullArray))
+
+	//Chan
+	require.False(compare.HasNilDifference(nullChan, nil))
+	require.True(compare.HasNilDifference(nullChan, nonNullChan))
+
+}
+


### PR DESCRIPTION
I found this bug while testing newly generated apigatewayv2 controller where the update code path was not triggered because no delta was being reported for an updated api resource.
The root cause was that string `pointers` were not being checked correctly for nil value. 

-----

To perform nil check on interfaces, only doing `i == nil` is not sufficient as pointed out in 
* https://tour.golang.org/methods/12
* https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1

---------

* I updated the nil check to check for value stored in the interface type as suggested by links above and then confirmed that delta path for apigatewayv2 controller was correctly working.
* I also added some unit tests for nil checks on interface types that can have nil values.