### PR TITLE
Returning the latest resource from the Delete() call

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -55,17 +55,26 @@ func (_m *AWSResourceManager) Create(_a0 context.Context, _a1 types.AWSResource)
 }
 
 // Delete provides a mock function with given fields: _a0, _a1
-func (_m *AWSResourceManager) Delete(_a0 context.Context, _a1 types.AWSResource) error {
+func (_m *AWSResourceManager) Delete(_a0 context.Context, _a1 types.AWSResource) (types.AWSResource, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource) error); ok {
+	var r0 types.AWSResource
+	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource) types.AWSResource); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.AWSResource)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.AWSResource) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ReadOne provides a mock function with given fields: _a0, _a1

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -59,8 +59,9 @@ type AWSResourceManager interface {
 	) (AWSResource, error)
 
 	// Delete attempts to destroy the supplied AWSResource in the backend AWS
-	// service API.
-	Delete(context.Context, AWSResource) error
+	// service API, returning an AWSResource representing the
+	// resource being deleted (if delete is asynchronous and takes time)
+	Delete(context.Context, AWSResource) (AWSResource, error)
 	// ARNFromName returns an AWS Resource Name from a given string name. This
 	// is useful for constructing ARNs for APIs that require ARNs in their
 	// GetAttributes operations but all we have (for new CRs at least) is a


### PR DESCRIPTION
Related issue: https://github.com/aws-controllers-k8s/community/issues/836

This PR contains code changes to patch custom resource with latest details during long running delete.
It does so if resource manager's Delete function return requeue related errors. 
The expectation is that resource manager's ReadOne method would set appropriate conditions (example: `ACK.ResourceSynced` to false with message) and provide latest details about the resource which is being deleted.
Conditions can also be set at some common place where common conditions logic should reside.

Testing:
`make test` passed for runtime.

**Alternate approach** that was considered, but was not taken up as it involved non-intrusive changes to resource manager's APIs. Following are the details:
Currently, [resource manager's `Delete` API](https://github.com/aws-controllers-k8s/code-generator/blob/main/templates/pkg/resource/manager.go.tpl#L136) returns only one data field of type `error`, it does not return `resource`.
Also, the [`sdk.go::sdkDelete()` logic](https://github.com/aws-controllers-k8s/code-generator/blob/main/templates/pkg/resource/sdk.go.tpl#L141) does not parse the return result output of service delete API.

It can be updated such that `sdk.go::sdkDelete()` logic parses the output response, and allows a `sdk_delete_post_set_output` hook for service controllers to have custom logic (as needed). The resultant resource reference would then be returned from this method.
In case, requeue is required then the return values from this method will have both resource, error (requeue type) as not nil.
And the [reconciler:cleanup() logic here](https://github.com/aws-controllers-k8s/runtime/blob/main/pkg/runtime/reconciler.go#L327), would patch the current resource with the returned resource from `rm.Delete()` call and return the error (if any).

Though this change is similar to the approach taken for [resource manager ReadOne here](https://github.com/aws-controllers-k8s/code-generator/blob/main/templates/pkg/resource/manager.go.tpl#L76-L78), this is more intrusive as it changes the Delete API's return type.
However, it does have advantage that there is no need for another ReadOne call from reconciler, and also provides flexibility to service controller's to implement custom hook specific to delete scenario.

[EDIT]: the alternate approach that is mentioned above, is the final approach taken per the discussion/comments in this PR.
Related PR in code-generator: https://github.com/aws-controllers-k8s/code-generator/pull/114
