### PR TITLE
Add a `pkg/webhook` package to standardize the way controllers create and register new webhooks

### DIFF
--- a/pkg/webhook/registry.go
+++ b/pkg/webhook/registry.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package webhook
+
+import "fmt"
+
+var (
+	// webhookRegistry is a map of webhooks, keyed by their unique
+	// identifier.
+	webhooksRegistry map[string]*Webhook
+)
+
+// GetWebhooks returns the list of webhooks that were registred with
+// RegisterWebhook function.
+func GetWebhooks() []*Webhook {
+	webhooks := make([]*Webhook, 0, len(webhooksRegistry))
+	for _, wh := range webhooksRegistry {
+		webhooks = append(webhooks, wh)
+	}
+	return webhooks
+}
+
+// RegisterWebhook registers a new webhook within the webhook registry.
+// This function will return an error if it tries to register two webhooks
+// with the same unique identifier.
+func RegisterWebhook(w *Webhook) error {
+	if webhooksRegistry == nil {
+		webhooksRegistry = make(map[string]*Webhook)
+	}
+
+	_, ok := webhooksRegistry[w.UID()]
+	if ok {
+		return fmt.Errorf("webhook %s already registred", w.UID())
+	}
+	webhooksRegistry[w.UID()] = w
+	return nil
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,59 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package webhook
+
+import (
+	"fmt"
+
+	ctrlrt "sigs.k8s.io/controller-runtime"
+)
+
+type WebhookType string
+
+const (
+	WebhookTypeUnknown    WebhookType = "unknown"
+	WebhookTypeConversion WebhookType = "conversion"
+	//TODO(a-hilaly) add validating and defaulting types
+)
+
+// Webhook contains information about a custom Webhook
+type Webhook struct {
+	Type       string
+	CRDKind    string
+	APIVersion string
+	// Setup is used to register the webhook within
+	// the webhook manager
+	Setup func(ctrlrt.Manager) error
+}
+
+// UID returns a unique identifier for the webhook. Webhooks
+// must be unique per CRD and APIVersion.
+func (w *Webhook) UID() string {
+	return fmt.Sprintf("%s/%s/%s", w.Type, w.CRDKind, w.APIVersion)
+}
+
+// New instanciate a new webhook object pointer.
+func New(
+	apiVersion string,
+	crdKind string,
+	type_ string,
+	setupFunc func(ctrlrt.Manager) error,
+) *Webhook {
+	return &Webhook{
+		Type:       type_,
+		CRDKind:    crdKind,
+		APIVersion: apiVersion,
+		Setup:      setupFunc,
+	}
+}


### PR DESCRIPTION
Adding a new package to systematize the way we create and register new
webhooks.

Introducing two files:
- `webhook.go` which contains the webhook structure and defines the
setup method that needs to be suplied by each CRD per APIVersion.
- `register.go` similarily to what a controller
`pkg/resource/register.go` does, this files exposes functions to register
and list the registered webhooks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.