### PR TITLE
Regenerate mocks package

### DIFF
--- a/mocks/pkg/types/aws_resource_manager_factory.go
+++ b/mocks/pkg/types/aws_resource_manager_factory.go
@@ -59,6 +59,20 @@ func (_m *AWSResourceManagerFactory) ManagerFor(_a0 config.Config, _a1 logr.Logg
 	return r0, r1
 }
 
+// RequeueOnSuccessSeconds provides a mock function with given fields:
+func (_m *AWSResourceManagerFactory) RequeueOnSuccessSeconds() int {
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
 // ResourceDescriptor provides a mock function with given fields:
 func (_m *AWSResourceManagerFactory) ResourceDescriptor() types.AWSResourceDescriptor {
 	ret := _m.Called()


### PR DESCRIPTION
Generate missing `RequeueOnSuccessSeconds` method of `mocks.AWSResourceManagerFactory`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.