### PR TITLE
Delete `--bind-port` flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	flagBindPort             = "bind-port"
 	flagEnableLeaderElection = "enable-leader-election"
 	flagMetricAddr           = "metrics-addr"
 	flagEnableDevLogging     = "enable-development-logging"
@@ -40,7 +39,6 @@ const (
 
 // Config contains configuration otpions for ACK service controllers
 type Config struct {
-	BindPort                 int
 	MetricsAddr              string
 	EnableLeaderElection     bool
 	EnableDevelopmentLogging bool
@@ -56,11 +54,6 @@ type Config struct {
 
 // BindFlags defines CLI/runtime configuration options
 func (cfg *Config) BindFlags() {
-	flag.IntVar(
-		&cfg.BindPort, flagBindPort,
-		9443,
-		"The port the service controller binds to.",
-	)
 	flag.StringVar(
 		&cfg.MetricsAddr, flagMetricAddr,
 		"0.0.0.0:8080",
@@ -69,11 +62,11 @@ func (cfg *Config) BindFlags() {
 	flag.BoolVar(
 		&cfg.EnableWebhookServer, flagEnableWebhookServer,
 		false,
-		"Enable webhook server for controller manager. ",
+		"Enable webhook server for controller manager.",
 	)
 	flag.StringVar(
 		&cfg.WebhookServerAddr, flagWebhookServerAddr,
-		"0.0.0.0:443",
+		"0.0.0.0:9433",
 		"The address the webhook endpoint binds to.",
 	)
 	flag.BoolVar(


### PR DESCRIPTION
Small rework of the `config` package that deleted `--bind-port`

NOTE: `Port` and `Host` options that are used to create a new
controller-runtime manager instance are used for the webhook server.
see https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L211-L216

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
