### PR TITLE
Reduce the number of instantiated/used `ackrtcache.Caches` objects.

### DIFF
--- a/pkg/runtime/cache/cache.go
+++ b/pkg/runtime/cache/cache.go
@@ -58,7 +58,7 @@ type Caches struct {
 
 // New creates a new Caches object from a kubernetes.Interface and
 // a logr.Logger
-func New(clientset kubernetes.Interface, log logr.Logger, watchNamespace  string) Caches {
+func New(clientset kubernetes.Interface, log logr.Logger, watchNamespace string) Caches {
 	return Caches{
 		Accounts:   NewAccountCache(clientset, log),
 		Namespaces: NewNamespaceCache(clientset, log, watchNamespace),

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
+	ackrtcache "github.com/aws-controllers-k8s/runtime/pkg/runtime/cache"
 
 	k8srtmocks "github.com/aws-controllers-k8s/runtime/mocks/apimachinery/pkg/runtime"
 	k8srtschemamocks "github.com/aws-controllers-k8s/runtime/mocks/apimachinery/pkg/runtime/schema"
@@ -142,7 +143,7 @@ func TestReconcilerUpdate(t *testing.T) {
 	// `AWSResourceDescriptor.Delta()` returned a non-empty Delta, that we end
 	// up calling the AWSResourceManager.Update() call in the Reconciler.Sync()
 	// method,
-	r := ackrt.NewReconcilerWithClient(sc, kc, rmf, fakeLogger, cfg, metrics)
+	r := ackrt.NewReconcilerWithClient(sc, kc, rmf, fakeLogger, cfg, metrics, ackrtcache.Caches{})
 
 	err := r.Sync(ctx, rm, desired)
 	require.Nil(err)
@@ -259,7 +260,7 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInMetadata(t *testing.T) {
 	// `AWSResourceDescriptor.Delta()` returned a non-empty Delta, that we end
 	// up calling the AWSResourceManager.Update() call in the Reconciler.Sync()
 	// method,
-	r := ackrt.NewReconcilerWithClient(sc, kc, rmf, fakeLogger, cfg, metrics)
+	r := ackrt.NewReconcilerWithClient(sc, kc, rmf, fakeLogger, cfg, metrics, ackrtcache.Caches{})
 
 	err := r.Sync(ctx, rm, desired)
 	require.Nil(err)
@@ -375,7 +376,7 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInSpec(t *testing.T) {
 	// `AWSResourceDescriptor.Delta()` returned a non-empty Delta, that we end
 	// up calling the AWSResourceManager.Update() call in the Reconciler.Sync()
 	// method,
-	r := ackrt.NewReconcilerWithClient(sc, kc, rmf, fakeLogger, cfg, metrics)
+	r := ackrt.NewReconcilerWithClient(sc, kc, rmf, fakeLogger, cfg, metrics, ackrtcache.Caches{})
 
 	err := r.Sync(ctx, rm, desired)
 	require.Nil(err)


### PR DESCRIPTION
Issue: N/A

Currently, each ACK reconciler uses its own `ackrtcache.Caches`
instance. Long term this might cause some issues since each Cache
instance require its own KubeClient/shared informer etc...

This patch reduces the number of instantiated and used
`ackrtcache.Caches` to one. All the reconcilers will now use a copy of
the same cache instance since it's thread-safe.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.