### PR TITLE
Fix reusing merge objects for patch without copying

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -342,8 +342,8 @@ func (r *resourceReconciler) patchResourceMetadataAndSpec(
 	rlog.Enter("kc.Patch (metadata + spec)")
 	err = r.kc.Patch(
 		ctx,
-		latest.RuntimeObject(),
-		client.MergeFrom(desired.RuntimeObject()),
+		latest.RuntimeObject().DeepCopyObject(),
+		client.MergeFrom(desired.RuntimeObject().DeepCopyObject()),
 	)
 	rlog.Exit("kc.Patch (metadata + spec)", err)
 	if err != nil {
@@ -376,7 +376,7 @@ func (r *resourceReconciler) patchResourceStatus(
 	err = r.kc.Status().Patch(
 		ctx,
 		latest.RuntimeObject().DeepCopyObject(),
-		client.MergeFrom(desired.RuntimeObject()),
+		client.MergeFrom(desired.RuntimeObject().DeepCopyObject()),
 	)
 	rlog.Exit("kc.Patch (status)", err)
 	if err != nil {

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -58,6 +58,7 @@ func TestReconcilerUpdate(t *testing.T) {
 
 	desiredRTObj := &k8srtmocks.Object{}
 	desiredRTObj.On("GetObjectKind").Return(objKind)
+	desiredRTObj.On("DeepCopyObject").Return(desiredRTObj)
 
 	desiredMetaObj := &k8sobj.Unstructured{}
 	desiredMetaObj.SetAnnotations(map[string]string{})
@@ -174,6 +175,7 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInMetadata(t *testing.T) {
 
 	desiredRTObj := &k8srtmocks.Object{}
 	desiredRTObj.On("GetObjectKind").Return(objKind)
+	desiredRTObj.On("DeepCopyObject").Return(desiredRTObj)
 
 	desiredMetaObj := &k8sobj.Unstructured{}
 	desiredMetaObj.SetAnnotations(map[string]string{})
@@ -291,6 +293,7 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInSpec(t *testing.T) {
 
 	desiredRTObj := &k8srtmocks.Object{}
 	desiredRTObj.On("GetObjectKind").Return(objKind)
+	desiredRTObj.On("DeepCopyObject").Return(desiredRTObj)
 
 	desiredMetaObj := &k8sobj.Unstructured{}
 	desiredMetaObj.SetAnnotations(map[string]string{})


### PR DESCRIPTION
I was seeing an issue where there was a delta in the spec, but it was never being applied back to the object. I tracked down that the `latest` object returned from `sdkFind` was correct, but the patch was not being applied.

When using the method that patches both spec and status, changes to the `latest` were being applied in the spec, but not in the status. The root cause of this is that the `client.MergeFrom` is overriding the `status` fields when merging the `spec` with `desired`. Therefore after patching the spec `desired == latest`.  This patch ensures that we copy the `latest` object as part of patching so as to not override changes when using `client.MergeFrom`.