### PR TITLE
cleanups and DRYing up the reconciler unit tests

### DIFF
--- a/mocks/pkg/types/aws_resource_descriptor.go
+++ b/mocks/pkg/types/aws_resource_descriptor.go
@@ -110,24 +110,3 @@ func (_m *AWSResourceDescriptor) ResourceFromRuntimeObject(_a0 runtime.Object) t
 
 	return r0
 }
-
-// UpdateCRStatus provides a mock function with given fields: _a0
-func (_m *AWSResourceDescriptor) UpdateCRStatus(_a0 types.AWSResource) (bool, error) {
-	ret := _m.Called(_a0)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(types.AWSResource) bool); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(types.AWSResource) error); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -369,13 +369,6 @@ func (r *resourceReconciler) patchResourceStatus(
 	exit := rlog.Trace("r.patchResourceStatus")
 	defer exit(err)
 
-	changedStatus, err := r.rd.UpdateCRStatus(latest)
-	if err != nil {
-		return err
-	}
-	if !changedStatus {
-		return nil
-	}
 	rlog.Enter("kc.Patch (status)")
 	// It is necessary to use `DeepCopyObject` versions of `latest` when calling
 	// `Patch` as this method overrides all values as merged from `desired`.

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -103,7 +103,6 @@ func TestReconcilerUpdate(t *testing.T) {
 		delta,
 	).Once()
 	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
-	rd.On("UpdateCRStatus", latest).Return(true, nil)
 	rd.On("IsManaged", desired).Return(true)
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -221,7 +220,6 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInMetadata(t *testing.T) {
 		delta,
 	).Once()
 	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
-	rd.On("UpdateCRStatus", latest).Return(true, nil)
 	rd.On("IsManaged", desired).Return(true)
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -338,7 +336,6 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInSpec(t *testing.T) {
 	rd.On("Delta", desired, latest).Return(
 		delta,
 	)
-	rd.On("UpdateCRStatus", latest).Return(true, nil)
 	rd.On("IsManaged", desired).Return(true)
 
 	rm := &ackmocks.AWSResourceManager{}

--- a/pkg/types/aws_resource_descriptor.go
+++ b/pkg/types/aws_resource_descriptor.go
@@ -37,10 +37,6 @@ type AWSResourceDescriptor interface {
 	// Delta returns an `ackcompare.Delta` object containing the difference between
 	// one `AWSResource` and another.
 	Delta(a, b AWSResource) *ackcompare.Delta
-	// UpdateCRStatus accepts an AWSResource object and changes the Status
-	// sub-object of the AWSResource's Kubernetes custom resource (CR) and
-	// returns whether any changes were made
-	UpdateCRStatus(AWSResource) (bool, error)
 	// IsManaged returns true if the supplied AWSResource is under the
 	// management of an ACK service controller. What this means in practice is
 	// that the underlying custom resource (CR) in the AWSResource has had a


### PR DESCRIPTION
Adds a series of cleanups to the `pkg/runtime/reconciler_test.go` unit test to reduce
the amount of repetitive setup code we had in there.

Also removes the unused `AWSResourceDescriptor.UpdateCRStatus` interface method.

By submitting this pull request, I confirm that my contribution is made under the terms
of the Apache 2.0 license.