### PR TITLE
simplify patching spec and status in reconciler

### DIFF
--- a/mocks/pkg/types/aws_resource_reconciler.go
+++ b/mocks/pkg/types/aws_resource_reconciler.go
@@ -52,6 +52,27 @@ func (_m *AWSResourceReconciler) GroupKind() *v1.GroupKind {
 	return r0
 }
 
+// HandleReconcileError provides a mock function with given fields: ctx, desired, latest, err
+func (_m *AWSResourceReconciler) HandleReconcileError(ctx context.Context, desired types.AWSResource, latest types.AWSResource, err error) (reconcile.Result, error) {
+	ret := _m.Called(ctx, desired, latest, err)
+
+	var r0 reconcile.Result
+	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource, types.AWSResource, error) reconcile.Result); ok {
+		r0 = rf(ctx, desired, latest, err)
+	} else {
+		r0 = ret.Get(0).(reconcile.Result)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.AWSResource, types.AWSResource, error) error); ok {
+		r1 = rf(ctx, desired, latest, err)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Reconcile provides a mock function with given fields: _a0
 func (_m *AWSResourceReconciler) Reconcile(_a0 reconcile.Request) (reconcile.Result, error) {
 	ret := _m.Called(_a0)
@@ -95,15 +116,24 @@ func (_m *AWSResourceReconciler) SecretValueFromReference(_a0 context.Context, _
 }
 
 // Sync provides a mock function with given fields: _a0, _a1, _a2
-func (_m *AWSResourceReconciler) Sync(_a0 context.Context, _a1 types.AWSResourceManager, _a2 types.AWSResource) error {
+func (_m *AWSResourceReconciler) Sync(_a0 context.Context, _a1 types.AWSResourceManager, _a2 types.AWSResource) (types.AWSResource, error) {
 	ret := _m.Called(_a0, _a1, _a2)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResourceManager, types.AWSResource) error); ok {
+	var r0 types.AWSResource
+	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResourceManager, types.AWSResource) types.AWSResource); ok {
 		r0 = rf(_a0, _a1, _a2)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.AWSResource)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.AWSResourceManager, types.AWSResource) error); ok {
+		r1 = rf(_a0, _a1, _a2)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }

--- a/pkg/types/aws_resource_reconciler.go
+++ b/pkg/types/aws_resource_reconciler.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlrt "sigs.k8s.io/controller-runtime"
 )
 
 // AWSResourceReconciler is responsible for reconciling the state of a SINGLE
@@ -37,11 +38,28 @@ type AWSResourceReconciler interface {
 	// Sync ensures that the supplied AWSResource's backing API resource
 	// matches the supplied desired state.
 	//
+	// It returns a copy of the resource that represents the latest observed
+	// state.
+	//
 	// NOTE(jaypipes): This is really only here for dependency injection
 	// purposes in unit testing in order to simplify test setups.
 	Sync(
 		context.Context,
 		AWSResourceManager,
 		AWSResource,
-	) error
+	) (AWSResource, error)
+	// HandleReconcileError will handle errors from reconcile handlers, which
+	// respects runtime errors.
+	//
+	// If the `latest` parameter is not nil, this function will ALWAYS patch the
+	// latest Status fields back to the Kubernetes API.
+	//
+	// NOTE(jaypipes): This is really only here for dependency injection
+	// purposes in unit testing in order to simplify test setups.
+	HandleReconcileError(
+		ctx context.Context,
+		desired AWSResource,
+		latest AWSResource,
+		err error,
+	) (ctrlrt.Result, error)
 }


### PR DESCRIPTION
The way that we were handling patching spec/metadata and status in the
main reconciler loop was starting to get awkward and messy. We were
calling `patchResource`, `patchResourceStatus` or
`patchResourceMetadataAndSpec` in quite a few places, the main
`resourceReconciler.Sync()` code path was getting messy and hard to
read, and we were in danger of having more subtle bugs creep into the
reconciler logic because of the duplicative patch calls and non-obvious
nature of the calls.

This patch simplifies and cleans up the logic around the core
`resourceReconciler.Sync()` code paths in the following ways:

* Breaks out the create and update code paths into their own separate
  `createResource` and `updateResource` methods.
* Renames the `cleanup` method to `deleteResource` in order to match the
  create and update methods
* Removes ALL calls to `patchResourceStatus` in favor of always ensuring
  Status patching is done in the
  `resourceReconciler.HandleReconcileError` wrapper method
* Removes the `resourceReconciler.patchResource` method entirely (which
  patched both Metadata/Spec as well as Status) and ensures that the
  `createResource`, `updateResource` and `deleteResource` methods on
  `resourceReconciler` only ever call `patchResourceMetadataAndSpec`
  (since `patchResourceStatus` is now always called by the
  `HandleReconcileError` wrapper)

These changes should make the late initialize work easier to fit into
the core reconciler logic and provide a more explicit contract about
what is responsible for patching status (**only** the
`HandleReconcileError` wrapper) and what is responsible for patching
metadata and spec (the `createResource`, `updateResource` and
`deleteResource` methods).

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.