### PR TITLE
Add manager filter for generation changed

### DIFF
--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -25,6 +25,7 @@ import (
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -57,6 +58,8 @@ func (r *adoptionReconciler) BindControllerManager(mgr ctrlrt.Manager) error {
 	).For(
 		// Read only adopted resource objects
 		&ackv1alpha1.AdoptedResource{},
+	).WithEventFilter(
+		predicate.GenerationChangedPredicate{},
 	).Complete(r)
 }
 

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -80,6 +81,8 @@ func (r *resourceReconciler) BindControllerManager(mgr ctrlrt.Manager) error {
 		mgr,
 	).For(
 		rd.EmptyRuntimeObject(),
+	).WithEventFilter(
+		predicate.GenerationChangedPredicate{},
 	).Complete(r)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/aws-controllers-k8s/community/issues/886

The reconciler will indefinitely requeue even when there have been no changes made to the `spec` or `status`. This is happening in both the adoption and resource reconciler types.

The root cause comes from `controller-runtime` requeue-ing the resource when we patch the `status` subresource - see [this issue](https://github.com/kubernetes-sigs/kubebuilder/issues/618) for details. This bug was introduced for the resource reconciler as part of #39 , since we now call `patchResourceStatus` on every reconcile loop.

This fix adds an event filter to each manager, with a predicate that the resource must have changed generation. The generation is not changed unless there has been a modification to the `spec` or `status`. 