### PR TITLE
Call `ReadOne` as part of `createResource`

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -265,11 +265,15 @@ func (r *resourceReconciler) createResource(
 	}
 
 	rlog.Enter("rm.ReadOne")
-	latest, err = rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latest)
 	rlog.Exit("rm.ReadOne", err)
 	if err != nil {
 		return latest, err
 	}
+
+	// Take the status from the latest ReadOne
+	latest.SetStatus(observed)
+
 	// Ensure that we are patching any changes to the annotations/metadata and
 	// the Spec that may have been set by the resource manager's successful
 	// Create call above.

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -263,6 +263,13 @@ func (r *resourceReconciler) createResource(
 	if err != nil {
 		return latest, err
 	}
+
+	rlog.Enter("rm.ReadOne")
+	latest, err = rm.ReadOne(ctx, latest)
+	rlog.Exit("rm.ReadOne", err)
+	if err != nil {
+		return latest, err
+	}
 	// Ensure that we are patching any changes to the annotations/metadata and
 	// the Spec that may have been set by the resource manager's successful
 	// Create call above.

--- a/pkg/types/aws_resource.go
+++ b/pkg/types/aws_resource.go
@@ -55,4 +55,6 @@ type AWSResource interface {
 	// SetIdentifiers will set the the Spec or Status field that represents the
 	// identifier for the resource.
 	SetIdentifiers(*ackv1alpha1.AWSIdentifiers) error
+	// SetStatus will set the Status field for the resource
+	SetStatus(AWSResource)
 }


### PR DESCRIPTION
Some status fields were not being set properly during the first reconciliation loop, as part of the Create flow. This loop called the `Create*` operation, and set any status fields that are returned as part of the output shape, and then returned successfully (without re-queuing). Previously, the reconciler would loop again to describe and set the other status fields, however we now filter out any events that do not change the resource generation. 

This fix will call `ReadOne` to describe the newly created resource and set the status fields based on that response, directly after calling `Create*`. This ensures all fields are set before completing the first reconciliation loop.