### PR TITLE
Use endpointResolver and add serviceEndpointsID to serviceController

### DIFF
--- a/pkg/runtime/service_controller.go
+++ b/pkg/runtime/service_controller.go
@@ -47,6 +47,8 @@ type serviceController struct {
 	// ServiceAPIGroup is a string with the full DNS-correct API group that
 	// this service controller manages, e.g. "s3.services.k8s.aws"
 	ServiceAPIGroup string
+	// ServiceEndpointsID is a string with the service API's EndpointsID, e.g. "api.sagemaker"
+	ServiceEndpointsID string
 	// VersionInfo describes the service controller's built code
 	VersionInfo VersionInfo
 	// rmFactories is a map of resource manager factories, keyed by the
@@ -163,12 +165,14 @@ func (c *serviceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg
 func NewServiceController(
 	svcAlias string,
 	svcAPIGroup string,
+	svcEndpointsID string,
 	versionInfo VersionInfo,
 ) acktypes.ServiceController {
 	return &serviceController{
-		ServiceAlias:    svcAlias,
-		ServiceAPIGroup: svcAPIGroup,
-		VersionInfo:     versionInfo,
-		metrics:         ackmetrics.NewMetrics(svcAlias),
+		ServiceAlias:       svcAlias,
+		ServiceAPIGroup:    svcAPIGroup,
+		ServiceEndpointsID: svcEndpointsID,
+		VersionInfo:        versionInfo,
+		metrics:            ackmetrics.NewMetrics(svcAlias),
 	}
 }

--- a/pkg/runtime/service_controller_test.go
+++ b/pkg/runtime/service_controller_test.go
@@ -107,9 +107,8 @@ func TestServiceController(t *testing.T) {
 		BuildDate:  "now",
 	}
 
-	sc := ackrt.NewServiceController("bookstore", "bookstore.services.k8s.aws", vi)
+	sc := ackrt.NewServiceController("bookstore", "bookstore.services.k8s.aws", "bookstore", vi)
 	require.NotNil(sc)
-
 	zapOptions := ctrlrtzap.Options{
 		Development: true,
 		Level:       zapcore.InfoLevel,

--- a/pkg/runtime/session.go
+++ b/pkg/runtime/session.go
@@ -42,8 +42,17 @@ func (c *serviceController) NewSession(
 		Region:              aws.String(string(region)),
 		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 	}
-	if endpointURL != nil {
-		awsCfg.Endpoint = endpointURL
+
+	if *endpointURL != "" {
+		endpointServiceResolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+			if service == c.ServiceEndpointsID {
+				return endpoints.ResolvedEndpoint{
+					URL: *endpointURL,
+				}, nil
+			}
+			return endpoints.DefaultResolver().EndpointFor(service, region)
+		}
+		awsCfg.EndpointResolver = endpoints.ResolverFunc(endpointServiceResolver)
 	}
 
 	sess, err := session.NewSession(&awsCfg)


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/896

Description of changes:
If `endpointURL` is not an empty string then we will use the `endpointresolver` and we will use this `endpointURL` when the service is equal to the `serviceEndpointID` which is retrieved from the service controller. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
