### PR TITLE
Set Terminal condition on updating unmanaged

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -21,6 +21,13 @@ import (
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
+var (
+	NotManagedMessage = "Resource already exists"
+	NotManagedReason  = "This resource already exists but is not managed by ACK. " +
+		"To bring the resource under ACK management, you should explicitly adopt " +
+		"the resource by creating a services.k8s.aws/AdoptedResource"
+)
+
 // Synced returns the Condition in the resource's Conditions collection that is
 // of type ConditionTypeResourceSynced. If no such condition is found, returns
 // nil.

--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -209,6 +209,7 @@ func (r *adoptionReconciler) sync(
 	}
 
 	described.SetObjectMeta(*targetMeta)
+	targetDescriptor.MarkManaged(described)
 	targetDescriptor.MarkAdopted(described)
 
 	if err := r.kc.Create(ctx, described.RuntimeObject()); err != nil {

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -562,9 +562,7 @@ func (r *resourceReconciler) failOnResourceUnmanaged(
 		return nil
 	}
 
-	notManagedMessage := "Resource already exists"
-	notManagedReason := "This resource already exists and is not managed by ACK"
-	condition.SetTerminal(res, corev1.ConditionTrue, &notManagedMessage, &notManagedReason)
+	condition.SetTerminal(res, corev1.ConditionTrue, &condition.NotManagedMessage, &condition.NotManagedReason)
 	return ackerr.Terminal
 }
 

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -28,6 +28,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
@@ -312,8 +313,8 @@ func (r *resourceReconciler) updateResource(
 	exit := rlog.Trace("r.updateResource")
 	defer exit(err)
 
-	// Ensure the resource is always managed (adopted resources apply)
-	if err = r.setResourceManaged(ctx, desired); err != nil {
+	// Ensure the resource is managed
+	if err = r.failOnResourceUnmanaged(ctx, latest); err != nil {
 		return latest, err
 	}
 
@@ -333,7 +334,7 @@ func (r *resourceReconciler) updateResource(
 		}
 		// Ensure that we are patching any changes to the annotations/metadata and
 		// the Spec that may have been set by the resource manager's successful
-		// Create call above.
+		// Update call above.
 		err = r.patchResourceMetadataAndSpec(ctx, desired, latest)
 		if err != nil {
 			return latest, err
@@ -402,13 +403,9 @@ func (r *resourceReconciler) patchResourceMetadataAndSpec(
 	}
 
 	rlog.Enter("kc.Patch (metadata + spec)")
-	// It is necessary to use `DeepCopyObject` versions of `latest` when calling
-	// `Patch` as this method overrides all values as merged from `desired`.
-	// This may affect `latest` in later execution, as otherwise this would set
-	//`desired` == `latest` after calling this method.
 	err = r.kc.Patch(
 		ctx,
-		latest.RuntimeObject().DeepCopyObject(),
+		latest.RuntimeObject(),
 		client.MergeFrom(desired.RuntimeObject().DeepCopyObject()),
 	)
 	rlog.Exit("kc.Patch (metadata + spec)", err)
@@ -432,13 +429,9 @@ func (r *resourceReconciler) patchResourceStatus(
 	defer exit(err)
 
 	rlog.Enter("kc.Patch (status)")
-	// It is necessary to use `DeepCopyObject` versions of `latest` when calling
-	// `Patch` as this method overrides all values as merged from `desired`.
-	// This may affect `latest` in later execution, as otherwise this would set
-	//`desired` == `latest` after calling this method.
 	err = r.kc.Status().Patch(
 		ctx,
-		latest.RuntimeObject().DeepCopyObject(),
+		latest.RuntimeObject(),
 		client.MergeFrom(desired.RuntimeObject().DeepCopyObject()),
 	)
 	rlog.Exit("kc.Patch (status)", err)
@@ -517,7 +510,6 @@ func (r *resourceReconciler) setResourceManaged(
 	if r.rd.IsManaged(res) {
 		return nil
 	}
-
 	var err error
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("r.setResourceManaged")
@@ -525,13 +517,7 @@ func (r *resourceReconciler) setResourceManaged(
 
 	orig := res.RuntimeObject().DeepCopyObject()
 	r.rd.MarkManaged(res)
-	rlog.Enter("kc.Patch (metadata + spec)")
-	err = r.kc.Patch(
-		ctx,
-		res.RuntimeObject(),
-		client.MergeFrom(orig),
-	)
-	rlog.Exit("kc.Patch (metadata + spec)", err)
+	err = r.patchResourceMetadataAndSpec(ctx, r.rd.ResourceFromRuntimeObject(orig), res)
 	if err != nil {
 		return err
 	}
@@ -557,18 +543,29 @@ func (r *resourceReconciler) setResourceUnmanaged(
 
 	orig := res.RuntimeObject().DeepCopyObject()
 	r.rd.MarkUnmanaged(res)
-	rlog.Enter("kc.Patch (metadata + spec)")
-	err = r.kc.Patch(
-		ctx,
-		res.RuntimeObject(),
-		client.MergeFrom(orig),
-	)
-	rlog.Exit("kc.Patch (metadata + spec)", err)
+	err = r.patchResourceMetadataAndSpec(ctx, r.rd.ResourceFromRuntimeObject(orig), res)
 	if err != nil {
 		return err
 	}
 	rlog.Debug("removed resource from management")
 	return nil
+}
+
+// failOnResourceUnmanaged ensures that the underlying CR in the supplied
+// AWSResource has a finalizer. If it does not, it will set a Terminal condition
+// and return with an error
+func (r *resourceReconciler) failOnResourceUnmanaged(
+	ctx context.Context,
+	res acktypes.AWSResource,
+) error {
+	if r.rd.IsManaged(res) {
+		return nil
+	}
+
+	notManagedMessage := "Resource already exists"
+	notManagedReason := "This resource already exists and is not managed by ACK"
+	condition.SetTerminal(res, corev1.ConditionTrue, &notManagedMessage, &notManagedReason)
+	return ackerr.Terminal
 }
 
 // getAWSResource returns an AWSResource representing the requested Kubernetes

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -114,7 +114,7 @@ func managerFactoryMocks(
 	rd.On("EmptyRuntimeObject").Return(
 		&fakeBook{},
 	)
-	rd.On("IsManaged", desired).Return(true)
+	rd.On("IsManaged", latest).Return(true)
 
 	rmf := &ackmocks.AWSResourceManagerFactory{}
 	rmf.On("ResourceDescriptor").Return(rd)


### PR DESCRIPTION
ACK uses finalizers to determine whether it is currently managing a k8s resource. We set the finalizer when creating the resource and delete it when we have deleted the underlying AWS resource. The current code path also sets the finalizer if one is not applied when attempting to update a resource. If a user were to create a resource that has the same name as an existing AWS resource, it will attempt to call `updateResource` which would set the finalizer and treat the resource as if ACK created it. This behaviour circumvents the safer adoption mechanisms put in place to prevent overriding existing resources.

This pull request ensures that any resource which does not have a finalizer, when attempting to call `updateResource`, will be marked with a terminal condition. Adopted resources are now marked with the finalizer when they are created. 