### PR TITLE
Adding abstractions for exponential backoff & retry during late initialization

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -1,0 +1,103 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package annotation
+
+import (
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+var (
+	LateInitializationAttempt = "services.k8s.aws/late-initialization-attempt"
+)
+
+// GetNumLateInitializationAttempt returns the number of late initialization
+// attempts made. This value is stored in the k8s resource annotation
+// 'services.k8s.aws/late-initialization-attempt'
+func GetNumLateInitializationAttempt(metav1Obj metav1.Object) int {
+	// Default is 1
+	if ackcompare.IsNil(metav1Obj) || metav1Obj.GetAnnotations() == nil {
+		return 1
+	}
+	if numLateInitAttemptStr, ok := metav1Obj.GetAnnotations()[LateInitializationAttempt]; ok {
+		numLateInitAttempt, err := strconv.Atoi(numLateInitAttemptStr)
+		if err == nil {
+			return numLateInitAttempt
+		}
+	}
+	return 1
+}
+
+// IncrementNumLateInitializationAttempt reads the number of late initialization
+// attempts from k8s resource annotation, increments by 1, and stores back into
+// k8s resource annotation
+// This method updates the object the passed in the parameter inplace. Make sure
+//to pass a pointer object for updates to reflect after method call.
+// NOTE: AWSResource.MetaObject() method for all ACK resources returns a pointer
+// , so this method is safe to use without return type.
+// Also See https://github.com/aws-controllers-k8s/community/issues/905
+func IncrementNumLateInitializationAttempt(metav1Obj metav1.Object) {
+	if ackcompare.IsNil(metav1Obj) {
+		return
+	}
+	annotations := metav1Obj.GetAnnotations()
+	if annotations != nil {
+		if currentNumAttemptStr, ok := annotations[LateInitializationAttempt]; ok {
+			if currentNumAttempt, err := strconv.Atoi(currentNumAttemptStr); err == nil {
+				SetNumLateInitializationAttempt(metav1Obj, currentNumAttempt+1)
+				return
+			}
+		}
+	}
+	// If late initialization attempt annotation is not present or value is not
+	// a number, reset to 1
+	SetNumLateInitializationAttempt(metav1Obj, 1)
+}
+
+// SetNumLateInitializationAttempt stores 'numAttempt' into k8s resource annotation
+// 'services.k8s.aws/late-initialization-attempt'
+// This method updates the object the passed in the parameter inplace. Make sure
+// to pass a pointer object for updates to reflect after method call.
+// NOTE: AWSResource.MetaObject() method for all ACK resources returns a pointer
+// , so this method is safe to use without return type.
+// Also See: https://github.com/aws-controllers-k8s/community/issues/905
+func SetNumLateInitializationAttempt(metav1Obj metav1.Object, numAttempt int) {
+	if ackcompare.IsNil(metav1Obj) {
+		return
+	}
+	annotations := make(map[string]string)
+	if metav1Obj.GetAnnotations() != nil {
+		annotations = metav1Obj.GetAnnotations()
+	}
+	annotations[LateInitializationAttempt] = strconv.Itoa(numAttempt)
+	metav1Obj.SetAnnotations(annotations)
+}
+
+// RemoveLateInitializationAttempt removes the 'services.k8s.aws/late-initialization-attempt'
+// annotation from k8s resource annotations
+// This method updates the object the passed in the parameter inplace. Make sure
+// to pass a pointer object for updates to reflect after method call.
+// NOTE: AWSResource.MetaObject() method for all ACK resources returns a pointer
+// , so this method is safe to use without return type.
+// Also See https://github.com/aws-controllers-k8s/community/issues/905
+func RemoveLateInitializationAttempt(metav1Obj metav1.Object) {
+	if ackcompare.IsNotNil(metav1Obj) && metav1Obj.GetAnnotations() != nil {
+		annotations := metav1Obj.GetAnnotations()
+		delete(annotations, LateInitializationAttempt)
+		metav1Obj.SetAnnotations(annotations)
+	}
+}

--- a/pkg/annotation/annotation_test.go
+++ b/pkg/annotation/annotation_test.go
@@ -1,0 +1,89 @@
+package annotation_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+	k8sobj "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/aws-controllers-k8s/runtime/pkg/annotation"
+)
+
+func TestGetNumLateInitializationAttempt(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(1, annotation.GetNumLateInitializationAttempt(nil))
+	obj := &k8sobj.Unstructured{}
+	obj.SetAnnotations(nil)
+	assert.Equal(1, annotation.GetNumLateInitializationAttempt(obj))
+	annotations := make(map[string]string)
+	obj.SetAnnotations(annotations)
+	assert.Equal(1, annotation.GetNumLateInitializationAttempt(obj))
+	annotations[annotation.LateInitializationAttempt] = "abcd"
+	obj.SetAnnotations(annotations)
+	assert.Equal(1, annotation.GetNumLateInitializationAttempt(obj))
+	annotations[annotation.LateInitializationAttempt] = "10"
+	obj.SetAnnotations(annotations)
+	assert.Equal(10, annotation.GetNumLateInitializationAttempt(obj))
+}
+
+func TestIncrementNumLateInitializationAttempt(t *testing.T) {
+	assert := assert.New(t)
+	// Handles nil parameter
+	annotation.IncrementNumLateInitializationAttempt(nil)
+	obj := &k8sobj.Unstructured{}
+	// nil annotations
+	obj.SetAnnotations(nil)
+	annotation.IncrementNumLateInitializationAttempt(obj)
+	assert.Equal("1", obj.GetAnnotations()[annotation.LateInitializationAttempt])
+
+	//empty annotations
+	obj.SetAnnotations(make(map[string]string))
+	annotation.IncrementNumLateInitializationAttempt(obj)
+	assert.Equal("1", obj.GetAnnotations()[annotation.LateInitializationAttempt])
+
+	obj.SetAnnotations(map[string]string{annotation.LateInitializationAttempt: "99"})
+	annotation.IncrementNumLateInitializationAttempt(obj)
+	assert.Equal("100", obj.GetAnnotations()[annotation.LateInitializationAttempt])
+}
+
+func TestSetNumLateInitializationAttempt(t *testing.T) {
+	assert := assert.New(t)
+	// Handles nil parameter
+	annotation.SetNumLateInitializationAttempt(nil, 10)
+	obj := &k8sobj.Unstructured{}
+	// nil annotations
+	obj.SetAnnotations(nil)
+	annotation.SetNumLateInitializationAttempt(obj, 10)
+	assert.Equal("10", obj.GetAnnotations()[annotation.LateInitializationAttempt])
+
+	//empty annotations
+	obj.SetAnnotations(make(map[string]string))
+	annotation.SetNumLateInitializationAttempt(obj, 10)
+	assert.Equal("10", obj.GetAnnotations()[annotation.LateInitializationAttempt])
+
+	obj.SetAnnotations(map[string]string{annotation.LateInitializationAttempt: "99"})
+	annotation.SetNumLateInitializationAttempt(obj, 10)
+	assert.Equal("10", obj.GetAnnotations()[annotation.LateInitializationAttempt])
+}
+
+func TestRemoveLateInitializationAttempt(t *testing.T) {
+	assert := assert.New(t)
+	// Handles nil parameter
+	annotation.RemoveLateInitializationAttempt(nil)
+	obj := &k8sobj.Unstructured{}
+	// nil annotations
+	obj.SetAnnotations(nil)
+	annotation.RemoveLateInitializationAttempt(obj)
+	assert.Nil(obj.GetAnnotations())
+
+	//empty annotations
+	obj.SetAnnotations(make(map[string]string))
+	annotation.RemoveLateInitializationAttempt(obj)
+	_, ok := obj.GetAnnotations()[annotation.LateInitializationAttempt]
+	assert.False(ok)
+
+	obj.SetAnnotations(map[string]string{annotation.LateInitializationAttempt: "99"})
+	annotation.RemoveLateInitializationAttempt(obj)
+	_, ok = obj.GetAnnotations()[annotation.LateInitializationAttempt]
+	assert.False(ok)
+}

--- a/pkg/annotation/annotation_test.go
+++ b/pkg/annotation/annotation_test.go
@@ -1,9 +1,22 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package annotation_test
 
 import (
 	"testing"
 
-	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	k8sobj "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/aws-controllers-k8s/runtime/pkg/annotation"
@@ -29,40 +42,50 @@ func TestGetNumLateInitializationAttempt(t *testing.T) {
 func TestIncrementNumLateInitializationAttempt(t *testing.T) {
 	assert := assert.New(t)
 	// Handles nil parameter
-	annotation.IncrementNumLateInitializationAttempt(nil)
+	err := annotation.IncrementNumLateInitializationAttempt(nil)
+	assert.NotNil(err)
+	assert.Equal("metav1Obj parameter should not be nil", err.Error())
 	obj := &k8sobj.Unstructured{}
 	// nil annotations
 	obj.SetAnnotations(nil)
-	annotation.IncrementNumLateInitializationAttempt(obj)
+	err = annotation.IncrementNumLateInitializationAttempt(obj)
+	assert.Nil(err)
 	assert.Equal("1", obj.GetAnnotations()[annotation.LateInitializationAttempt])
 
 	//empty annotations
 	obj.SetAnnotations(make(map[string]string))
-	annotation.IncrementNumLateInitializationAttempt(obj)
+	err = annotation.IncrementNumLateInitializationAttempt(obj)
+	assert.Nil(err)
 	assert.Equal("1", obj.GetAnnotations()[annotation.LateInitializationAttempt])
 
 	obj.SetAnnotations(map[string]string{annotation.LateInitializationAttempt: "99"})
-	annotation.IncrementNumLateInitializationAttempt(obj)
+	err = annotation.IncrementNumLateInitializationAttempt(obj)
+	assert.Nil(err)
 	assert.Equal("100", obj.GetAnnotations()[annotation.LateInitializationAttempt])
 }
 
 func TestSetNumLateInitializationAttempt(t *testing.T) {
 	assert := assert.New(t)
 	// Handles nil parameter
-	annotation.SetNumLateInitializationAttempt(nil, 10)
+	err := annotation.SetNumLateInitializationAttempt(nil, 10)
+	assert.NotNil(err)
+	assert.Equal("metav1Obj parameter should not be nil", err.Error())
 	obj := &k8sobj.Unstructured{}
 	// nil annotations
 	obj.SetAnnotations(nil)
-	annotation.SetNumLateInitializationAttempt(obj, 10)
+	err = annotation.SetNumLateInitializationAttempt(obj, 10)
+	assert.Nil(err)
 	assert.Equal("10", obj.GetAnnotations()[annotation.LateInitializationAttempt])
 
 	//empty annotations
 	obj.SetAnnotations(make(map[string]string))
-	annotation.SetNumLateInitializationAttempt(obj, 10)
+	err = annotation.SetNumLateInitializationAttempt(obj, 10)
+	assert.Nil(err)
 	assert.Equal("10", obj.GetAnnotations()[annotation.LateInitializationAttempt])
 
 	obj.SetAnnotations(map[string]string{annotation.LateInitializationAttempt: "99"})
-	annotation.SetNumLateInitializationAttempt(obj, 10)
+	err = annotation.SetNumLateInitializationAttempt(obj, 10)
+	assert.Nil(err)
 	assert.Equal("10", obj.GetAnnotations()[annotation.LateInitializationAttempt])
 }
 

--- a/pkg/types/retry.go
+++ b/pkg/types/retry.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package types
+
+import (
+	"math"
+	"time"
+)
+
+// Exponential type helps in implementing exponential backoff strategy.
+type Exponential struct {
+	// Initial holds the initial delay.
+	Initial time.Duration
+	// Factor holds the factor that the delay time will be multiplied
+	// by on each iteration. If this is zero, a factor of two will be used.
+	Factor float64
+	// MaxDelay holds the maximum delay between the start.
+	// If this is zero, there is no maximum delay.
+	MaxDelay time.Duration
+}
+
+// GetBackoff returns the exponentialBackoff duration for the LateInitializationConfig
+// based on the 'numAttempts' parameter
+func (l *Exponential) GetBackoff(numAttempt int) time.Duration {
+	// return Initial as default
+	if numAttempt <= 0 {
+		return l.Initial
+	}
+	// Default base = 2
+	var base float64 = 2
+	if l.Factor != 0 {
+		base = l.Factor
+	}
+	additionalDelaySeconds := math.Pow(base, float64(numAttempt-1))
+	netBackoff := time.Duration(l.Initial.Seconds()+additionalDelaySeconds) * time.Second
+	// If the user provided MaxDelay, do not exceed that limit
+	if l.MaxDelay != 0 && l.MaxDelay > l.Initial {
+		netBackoff = time.Duration(math.Min(netBackoff.Seconds(), l.MaxDelay.Seconds())) * time.Second
+	}
+	return netBackoff
+}

--- a/pkg/types/retry_test.go
+++ b/pkg/types/retry_test.go
@@ -1,0 +1,128 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+)
+
+func TestExponential_GetBackoff(t *testing.T) {
+	type fields struct {
+		Initial  time.Duration
+		Factor   float64
+		MaxDelay time.Duration
+	}
+	type args struct {
+		numAttempt int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Duration
+	}{
+		{
+			name:   "Default Values,Zero Attempt",
+			fields: fields{},
+			args:   args{0},
+			want:   time.Duration(0) * time.Second,
+		},
+		{
+			name:   "Default Values,First Attempt",
+			fields: fields{},
+			args:   args{1},
+			want:   time.Duration(1) * time.Second,
+		},
+		{
+			name:   "Default Values,Fifth Attempt",
+			fields: fields{},
+			args:   args{5},
+			want:   time.Duration(16) * time.Second,
+		},
+		{
+			name:   "Only Min,Zero Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second},
+			args:   args{0},
+			want:   time.Duration(5) * time.Second,
+		},
+		{
+			name:   "Only Min,First Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second},
+			args:   args{1},
+			want:   time.Duration(6) * time.Second,
+		},
+		{
+			name:   "Only Min,Fifth Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second},
+			args:   args{5},
+			want:   time.Duration(21) * time.Second,
+		},
+		{
+			name:   "Only Max,Zero Attempt",
+			fields: fields{MaxDelay: time.Duration(10) * time.Second},
+			args:   args{0},
+			want:   time.Duration(0) * time.Second,
+		},
+		{
+			name:   "Only Max,First Attempt",
+			fields: fields{MaxDelay: time.Duration(10) * time.Second},
+			args:   args{1},
+			want:   time.Duration(1) * time.Second,
+		},
+		{
+			name:   "Only Max,Fifth Attempt",
+			fields: fields{MaxDelay: time.Duration(10) * time.Second},
+			args:   args{5},
+			want:   time.Duration(10) * time.Second,
+		},
+		{
+			name:   "Min & Max,Zero Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second, MaxDelay: time.Duration(15) * time.Second},
+			args:   args{0},
+			want:   time.Duration(5) * time.Second,
+		},
+		{
+			name:   "Min & Max,First Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second, MaxDelay: time.Duration(15) * time.Second},
+			args:   args{1},
+			want:   time.Duration(6) * time.Second,
+		},
+		{
+			name:   "Min & Max,Fifth Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second, MaxDelay: time.Duration(15) * time.Second},
+			args:   args{5},
+			want:   time.Duration(15) * time.Second,
+		},
+		{
+			name:   "Min & Max,Factor 3, Zero Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second, Factor: 3, MaxDelay: time.Duration(15) * time.Second},
+			args:   args{0},
+			want:   time.Duration(5) * time.Second,
+		},
+		{
+			name:   "Min & Max,Factor 3, Second Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second, Factor: 3, MaxDelay: time.Duration(15) * time.Second},
+			args:   args{2},
+			want:   time.Duration(8) * time.Second,
+		},
+		{
+			name:   "Min & Max,Factor 3, Fifth Attempt",
+			fields: fields{Initial: time.Duration(5) * time.Second, Factor: 3, MaxDelay: time.Duration(15) * time.Second},
+			args:   args{5},
+			want:   time.Duration(15) * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &acktypes.Exponential{
+				Initial:  tt.fields.Initial,
+				Factor:   tt.fields.Factor,
+				MaxDelay: tt.fields.MaxDelay,
+			}
+			if got := l.GetBackoff(tt.args.numAttempt); got != tt.want {
+				t.Errorf("GetBackoff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue # https://github.com/aws-controllers-k8s/community/issues/812

* Adds new pkg/annotation to handle lateInitializationAttempt annotations
* Adds new Exponential struct to handle exponential backoff and retry calculations.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.