### PR TITLE
Reset the object status after patching resource metadata & spec.

### DIFF
--- a/mocks/pkg/types/aws_resource.go
+++ b/mocks/pkg/types/aws_resource.go
@@ -34,6 +34,22 @@ func (_m *AWSResource) Conditions() []*v1alpha1.Condition {
 	return r0
 }
 
+// DeepCopy provides a mock function with given fields:
+func (_m *AWSResource) DeepCopy() types.AWSResource {
+	ret := _m.Called()
+
+	var r0 types.AWSResource
+	if rf, ok := ret.Get(0).(func() types.AWSResource); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.AWSResource)
+		}
+	}
+
+	return r0
+}
+
 // Identifiers provides a mock function with given fields:
 func (_m *AWSResource) Identifiers() types.AWSResourceIdentifiers {
 	ret := _m.Called()

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -403,12 +403,18 @@ func (r *resourceReconciler) patchResourceMetadataAndSpec(
 	}
 
 	rlog.Enter("kc.Patch (metadata + spec)")
+	// Save a copy of the latest object, to reset 'Status' after performing
+	// the kc.Patch() operation
+	latestCopy := latest.DeepCopy()
 	err = r.kc.Patch(
 		ctx,
 		latest.RuntimeObject(),
 		client.MergeFrom(desired.RuntimeObject().DeepCopyObject()),
 	)
+	// Reset the status of latest object after patching.
+	latest.SetStatus(latestCopy)
 	rlog.Exit("kc.Patch (metadata + spec)", err)
+
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -74,6 +74,9 @@ func resourceMocks() (
 	res := &ackmocks.AWSResource{}
 	res.On("MetaObject").Return(metaObj)
 	res.On("RuntimeObject").Return(rtObj)
+	res.On("DeepCopy").Return(res)
+	// DoNothing on SetStatus call.
+	res.On("SetStatus", res).Return(func(res ackmocks.AWSResource) {})
 
 	return res, rtObj, metaObj
 }
@@ -244,6 +247,8 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInMetadata(t *testing.T) {
 	// Only the HandleReconcilerError wrapper function ever calls patchResourceStatus
 	kc.AssertNotCalled(t, "Status")
 	rm.AssertCalled(t, "LateInitialize", ctx, latest)
+	latest.AssertCalled(t, "DeepCopy")
+	latest.AssertCalled(t, "SetStatus", latest)
 }
 
 func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInSpec(t *testing.T) {

--- a/pkg/types/aws_resource.go
+++ b/pkg/types/aws_resource.go
@@ -57,4 +57,6 @@ type AWSResource interface {
 	SetIdentifiers(*ackv1alpha1.AWSIdentifiers) error
 	// SetStatus will set the Status field for the resource
 	SetStatus(AWSResource)
+	// DeepCopy will return a copy of the resource
+	DeepCopy() AWSResource
 }


### PR DESCRIPTION
Description of changes:
* Introduces a new `DeepCopy` method in AWSResource interface
* After the fixes made in release v0.12.0, the status of latest object was getting modified during PatchMetadataAndSpec call.
* The problem was surfaced in one of the test in SageMaker that rely on waiting on  Status.Condition.
* Since the condition was being reset by the PatchMetadataAndSpec call, the test was never passing.
* I tried multiple things like 
    (a) Passing empty status in the base parameter during `kc.Patch()` call, but the `kc.Patch` call resets the status by reading it  from etcd.
* At this point, to understand this problem more, I will have to deep dive into kc.Patch source code.
* To unblock sagemaker team from developing their controller, I propose the change in following PR which is safe and unblocks the team.
* It is some redundant work in copying the status again but hopefully when we understand the `kc.Patch` operation better, we can improve on it.
* I have tested with sagemaker e2e that following solution works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
