### PR TITLE
do not patch status if resource is not managed

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -474,11 +474,14 @@ func (r *resourceReconciler) deleteResource(
 	if err != nil {
 		if err == ackerr.NotFound {
 			// If the aws resource is not found, remove finalizer
-			// and finish reconciliation
 			if err = r.setResourceUnmanaged(ctx, current); err != nil {
 				return current, err
 			}
 			rlog.Info("deleted resource")
+
+			// Return nil resource so that patchStatus attempt is not made.
+			// Underlying K8s resource gets deleted after removing finalizer string and
+			// patchStatus call will return NotFound error.
 			return nil, nil
 		}
 		return current, err
@@ -511,8 +514,9 @@ func (r *resourceReconciler) deleteResource(
 	}
 	rlog.Info("deleted resource")
 
-	// Since the finalizer has been removed, the controller should successfully
-	// reconcile
+	// Return nil resource so that patchStatus attempt is not made.
+	// Underlying K8s resource gets deleted after removing finalizer string and
+	// patchStatus call will return NotFound error.
 	return nil, nil
 }
 

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -474,7 +474,12 @@ func (r *resourceReconciler) deleteResource(
 	if err != nil {
 		if err == ackerr.NotFound {
 			// If the aws resource is not found, remove finalizer
-			return current, r.setResourceUnmanaged(ctx, current)
+			// and finish reconciliation
+			if err = r.setResourceUnmanaged(ctx, current); err != nil {
+				return current, err
+			}
+			rlog.Info("deleted resource")
+			return nil, nil
 		}
 		return current, err
 	}
@@ -505,7 +510,10 @@ func (r *resourceReconciler) deleteResource(
 		return latest, err
 	}
 	rlog.Info("deleted resource")
-	return latest, nil
+
+	// Since the finalizer has been removed, the controller should successfully
+	// reconcile
+	return nil, nil
 }
 
 // setResourceManaged marks the underlying CR in the supplied AWSResource with

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -474,15 +474,7 @@ func (r *resourceReconciler) deleteResource(
 	if err != nil {
 		if err == ackerr.NotFound {
 			// If the aws resource is not found, remove finalizer
-			if err = r.setResourceUnmanaged(ctx, current); err != nil {
-				return current, err
-			}
-			rlog.Info("deleted resource")
-
-			// Return nil resource so that patchStatus attempt is not made.
-			// Underlying K8s resource gets deleted after removing finalizer string and
-			// patchStatus call will return NotFound error.
-			return nil, nil
+			return current, r.setResourceUnmanaged(ctx, current)
 		}
 		return current, err
 	}
@@ -509,15 +501,16 @@ func (r *resourceReconciler) deleteResource(
 	// Now that external AWS service resources have been appropriately cleaned
 	// up, we remove the finalizer representing the CR is managed by ACK,
 	// allowing the CR to be deleted by the Kubernetes API server
-	if err = r.setResourceUnmanaged(ctx, current); err != nil {
-		return latest, err
+	if ackcompare.IsNotNil(latest) {
+		err = r.setResourceUnmanaged(ctx, latest)
+	} else {
+		err = r.setResourceUnmanaged(ctx, current)
 	}
-	rlog.Info("deleted resource")
+	if err == nil {
+		rlog.Info("deleted resource")
+	}
 
-	// Return nil resource so that patchStatus attempt is not made.
-	// Underlying K8s resource gets deleted after removing finalizer string and
-	// patchStatus call will return NotFound error.
-	return nil, nil
+	return latest, err
 }
 
 // setResourceManaged marks the underlying CR in the supplied AWSResource with
@@ -656,11 +649,15 @@ func (r *resourceReconciler) HandleReconcileError(
 	latest acktypes.AWSResource,
 	err error,
 ) (ctrlrt.Result, error) {
-	if ackcompare.IsNotNil(latest) {
+	if ackcompare.IsNotNil(latest) && r.rd.IsManaged(latest) {
 		// The reconciliation loop may have returned an error, but if latest is
 		// not nil, there may be some changes available in the CR's Status
 		// struct (example: Conditions), and we want to make sure we save those
 		// changes before proceeding
+		//
+		// Attempt to patch the status only if the resource is managed.
+		// Otherwise, the underlying K8s resource gets deleted and
+		// patchStatus call will return NotFound error
 		//
 		// TODO(jaypipes): We ignore error handling here but I don't know if
 		// there is a more robust way to handle failures in the patch operation


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/931

Description of changes:
Solution 1 in the issue linked above - `return nil, nil` instead of `resource, nil` after finalizer is removed 

Testing:
`make test`
Manually using sagemaker controller

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
