### PR TITLE
use sts GetCallerIdentity to find AWS AccountID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ any 'help wanted' issues is a great place to start.
 
 [See the documentation][dev-docs] for detailed development information.
 
-[dev-docs]: https://aws.github.io/aws-controllers-k8s/dev-docs/overview/
+[dev-docs]: https://aws-controllers-k8s.github.io/community/docs/contributor-docs/overview/
 
 ## Code of Conduct
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.1
+	github.com/jaypipes/envutil v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jaypipes/envutil v1.0.0 h1:u6Vwy9HwruFihoZrL0bxDLCa/YNadGVwKyPElNmZWow=
+github.com/jaypipes/envutil v1.0.0/go.mod h1:vgIRDly+xgBq0eeZRcflOHMMobMwgC6MkMbxo/Nw65M=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"net/url"
 
+	"github.com/jaypipes/envutil"
 	flag "github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	ctrlrt "sigs.k8s.io/controller-runtime"
@@ -83,12 +84,12 @@ func (cfg *Config) BindFlags() {
 	)
 	flag.StringVar(
 		&cfg.AccountID, flagAWSAccountID,
-		"",
+		envutil.WithDefault("AWS_ACCOUNT_ID", ""),
 		"The AWS Account ID in which the service controller will create resources",
 	)
 	flag.StringVar(
 		&cfg.Region, flagAWSRegion,
-		"",
+		envutil.WithDefault("AWS_REGION", ""),
 		"The AWS Region in which the service controller will create its resources",
 	)
 	flag.StringVar(


### PR DESCRIPTION
Description of changes:

Breaking changes : Removing --aws-account-id flag from controller binary. This flag can allow users to enter wrong account_id during controller installation which can cause incorrect controller logs and confusion

* If `aws-region` flags are missing, default to 'AWS_REGION' env variable
* Add new method `Config.SetAccountID()` to use sts `GetCallerIdentity` for detecting aws account-id.

------------------

* TODO: code-gen update to remove `--aws-account-id` flag, community repo docs update and test-infra update to drop `aws-account-id` from `test-helm.sh` & `kind-build-test.sh`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
