### PR TITLE
reduce resourceLog.blockDepth on Exit method

### DIFF
--- a/pkg/runtime/log/resource.go
+++ b/pkg/runtime/log/resource.go
@@ -87,6 +87,7 @@ func (rl *ResourceLogger) Exit(
 		}
 		vals := expandResourceFields(rl.res, additionalValues...)
 		rl.log.V(1).Info(msg, vals...)
+		rl.blockDepth--
 	}
 }
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1001

Description of changes:
* reducing blockDepth on Exit method
* Tested locally that it fixes resourceLogger

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
