### PR TITLE
fix log value dedupe in reconciler.go

### DIFF
--- a/pkg/runtime/log/resource.go
+++ b/pkg/runtime/log/resource.go
@@ -112,7 +112,7 @@ func NewResourceLogger(
 	additionalValues ...interface{},
 ) *ResourceLogger {
 	return &ResourceLogger{
-		log:        AdaptResource(log, res, additionalValues...),
+		log:        log.WithValues(additionalValues...),
 		res:        res,
 		blockDepth: 0,
 	}
@@ -158,15 +158,8 @@ func expandResourceFields(
 	additionalValues ...interface{},
 ) []interface{} {
 	metaObj := res.MetaObject()
-	ns := metaObj.GetNamespace()
-	resName := metaObj.GetName()
 	generation := metaObj.GetGeneration()
-	rtObj := res.RuntimeObject()
-	kind := rtObj.GetObjectKind().GroupVersionKind().Kind
 	vals := []interface{}{
-		"kind", kind,
-		"namespace", ns,
-		"name", resName,
 		"generation", generation,
 	}
 	if len(additionalValues) > 0 {

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -155,6 +155,11 @@ func (r *resourceReconciler) Reconcile(req ctrlrt.Request) (ctrlrt.Result, error
 		"account", acctID,
 		"role", roleARN,
 		"region", region,
+		// All the fields for a resource that do not change during reconciliation
+		// can be initialized during resourceLogger creation
+		"kind", r.rd.GroupKind().Kind,
+		"namespace", req.Namespace,
+		"name", req.Name,
 	)
 	ctx = context.WithValue(ctx, ackrtlog.ContextKey, rlog)
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1001

Description of changes:
* "Kind" value in logs was empty because `Get` from K8s typed client does not unmarshall GVK fields. We need to use dynamic client OR deduce GVK from `scheme` object. However to set "Kind" field in logs, resource-descriptor can be used and easily fix this bug.
* Other resource fields(name, namespace, generation) were getting duped in logs because resourceLogger constructor was deducing them and setting them in `r.log` values. When INFO or DEBUG method was called, they were getting deduced again and added as additional values. To fix this, during construction, we do not deduce fields from resource.

Additional changes:
* Fields like name, namespace, kind do not change during reconciliation of the object so we can set them once during construction of resource logger
* Only generation field is calculated on INFO/DEBUG methods
* Adoption reconciler logger did not have these bugs. Adoption reconciler finds Kind from "adoptedResource.Spec" and does not use constructor for resource logger.

Tested locally and validated the logs.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
