### PR TITLE
add clarity to validate error message

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,7 +153,7 @@ func (cfg *Config) SetAWSAccountID() error {
 // Validate ensures the options are valid
 func (cfg *Config) Validate() error {
 	if err := cfg.SetAWSAccountID(); err != nil {
-		return errors.New("unable to determine account ID. Please make sure AWS credentials are setup in controller pod")
+		return fmt.Errorf("unable to determine account ID: %v", err)
 	}
 
 	if cfg.Region == "" {


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
With the removal of `--aws-account-id` the validate error message that gets propagated is less clear then it used to be. This PR aims to add more clarity to the error message that gets propagated when `ack_user_secrets` does not exist in the namespace that a given controller runs in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
