### PR TITLE
clear conditions on loop start and ensure synced

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -157,3 +157,10 @@ func LateInitializationInProgress(subject acktypes.ConditionManager) bool {
 	c := LateInitialized(subject)
 	return c != nil && c.Status == corev1.ConditionFalse
 }
+
+// Clear resets the resource's collection of Conditions to an empty list.
+func Clear(
+	subject acktypes.ConditionManager,
+) {
+	subject.ReplaceConditions([]*ackv1alpha1.Condition{})
+}


### PR DESCRIPTION
This is the first patch that looks at cleaning up our handling of
Condition objects for resources. We make a change to the common runtime
to clear all Condition objects from the desired resource's
Status.Conditions collection at the beginning of the reconciliation loop
and add a deferred call to a function that ensures that an
ACK.ResourceSynced condition has been placed on the resource if the
resource manager has failed to add one.

Future patches will add functionality to the code generator to allow
programmatic control over when generated resource managers set
ACK.ResourceSynced conditions on their resources.

Issue: aws-controllers-k8s/community#1030

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
