### PR TITLE
ensure Status.Conditions before patching resource status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/runtime
 go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.42.35
+	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.5
 	github.com/jaypipes/envutil v1.0.0
@@ -44,7 +44,7 @@ require (
 	github.com/stretchr/objx v0.1.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
+	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws/aws-sdk-go v1.42.35 h1:N4N9buNs4YlosI9N0+WYrq8cIZwdgv34yRbxzZlTvFs=
-github.com/aws/aws-sdk-go v1.42.35/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
+github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
+github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -590,9 +590,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210825183410-e898025ed96a h1:bRuuGXV8wwSdGTB+CtJf+FjgO1APK1CoO39T4BN/XBw=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
-golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -244,6 +244,15 @@ func (r *resourceReconciler) Sync(
 	// Attempt to late initialize the resource. If there are no fields to
 	// late initialize, this operation will be a no-op.
 	if latest, err = r.lateInitializeResource(ctx, rm, latest); err != nil {
+		// TODO(vijtrip2): move this condition handling to generated
+		// AWSResourceManager.LateInitialize() method
+
+		// Whenever late initialization fails for a resource, set ACK.ResourceSynced
+		// condition explicitly to "False"
+		// Setting this explicitly to False is required because ACK.ResourceSynced
+		// condition can be True due to successful Create/Update call OR no
+		// Create/Update call in reconciler loop
+		ackcondition.SetSynced(latest, corev1.ConditionFalse, nil, nil)
 		return latest, err
 	}
 	return r.handleRequeues(ctx, latest)
@@ -289,11 +298,16 @@ func (r *resourceReconciler) ensureConditions(
 		// stable sync state. Even if we got no error back from the
 		// create/update operations, we can only set this to Unknown.
 		condStatus := corev1.ConditionUnknown
-		if reconcileErr == ackerr.Terminal {
-			// A terminal condition by its very nature indicates a stable state
-			// for a resource being synced. The resource is considered synced
-			// because its state will not change.
-			condStatus = corev1.ConditionTrue
+		if reconcileErr != nil {
+			if reconcileErr == ackerr.Terminal {
+				// A terminal condition by its very nature indicates a stable state
+				// for a resource being synced. The resource is considered synced
+				// because its state will not change.
+				condStatus = corev1.ConditionTrue
+			} else {
+				// For any other reconciler error, set synced condition to false
+				condStatus = corev1.ConditionFalse
+			}
 		}
 		ackcondition.SetSynced(res, condStatus, nil, nil)
 	}
@@ -409,6 +423,10 @@ func (r *resourceReconciler) updateResource(
 			return latest, err
 		}
 		rlog.Info("updated resource")
+	} else {
+		// If there is no delta between desired state and latest state, it is
+		// safe to set ACK.ResourceSynced condition to true.
+		ackcondition.SetSynced(latest, corev1.ConditionTrue, nil, nil)
 	}
 	return latest, nil
 }

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -208,7 +208,9 @@ func (r *resourceReconciler) Sync(
 	var latest acktypes.AWSResource // the newly created or mutated resource
 
 	r.resetConditions(ctx, desired)
-	defer r.ensureConditions(ctx, latest, err)
+	defer func() {
+		r.ensureConditions(ctx, latest, err)
+	}()
 
 	isAdopted := IsAdopted(desired)
 	rlog.WithValues("is_adopted", isAdopted)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1133

Description of changes:
* the logic for ensuring conditions was never been executed because the resource parameter(`latest`) passed in the defer call was always nil . See [Why](https://stackoverflow.com/a/42703862)
* If the `desired` and `latest` state have no delta, set `ResourceSynced` condition to `True`
* Set `ResourceSynced` condition to `False` when there is error in `LateInitialization`
* For any reconciler error, except Terminal, if ResourceSynced condition is missing, set it to `False`
* If there are no reconciler error, and ResourceSynced condition is missing, set it to `Unknown`
* Revert aws-sdk-go upgrade and handle that in separate release.
---

Tested these changes locally for iam-controller and tests pass successfully validating ResourceSynced condition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
