### PR TITLE
Add `IsSynced` function to the `AWSResource` interface

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -78,6 +78,27 @@ func (_m *AWSResourceManager) Delete(_a0 context.Context, _a1 types.AWSResource)
 	return r0, r1
 }
 
+// IsSynced provides a mock function with given fields: _a0, _a1
+func (_m *AWSResourceManager) IsSynced(_a0 context.Context, _a1 types.AWSResource) (bool, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource) bool); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.AWSResource) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LateInitialize provides a mock function with given fields: _a0, _a1
 func (_m *AWSResourceManager) LateInitialize(_a0 context.Context, _a1 types.AWSResource) (types.AWSResource, error) {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -83,6 +83,8 @@ type AWSResourceManager interface {
 	// This method also adds/updates the ConditionTypeReferencesResolved for the
 	// AWSResource.
 	ResolveReferences(context.Context, client.Reader, AWSResource) (AWSResource, error)
+	// IsSynced returns true if a resource is synced.
+	IsSynced(context.Context, AWSResource) (bool, error)
 }
 
 // AWSResourceManagerFactory returns an AWSResourceManager that can be used to


### PR DESCRIPTION
Follow up to https://github.com/aws-controllers-k8s/code-generator/pull/247

Description of changes:
- Add `IsSynced` function to the `AWSResource` interface

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
