### PR TITLE
Set synced when missing

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -78,27 +78,6 @@ func (_m *AWSResourceManager) Delete(_a0 context.Context, _a1 types.AWSResource)
 	return r0, r1
 }
 
-// IsSynced provides a mock function with given fields: _a0, _a1
-func (_m *AWSResourceManager) IsSynced(_a0 context.Context, _a1 types.AWSResource) (bool, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource) bool); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.AWSResource) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // LateInitialize provides a mock function with given fields: _a0, _a1
 func (_m *AWSResourceManager) LateInitialize(_a0 context.Context, _a1 types.AWSResource) (types.AWSResource, error) {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -424,9 +424,12 @@ func (r *resourceReconciler) updateResource(
 		}
 		rlog.Info("updated resource")
 	} else {
-		// If there is no delta between desired state and latest state, it is
+		// If there is no delta between desired state and latest state, and
+		// ACK.ResourceSynced condition is not already set, it is
 		// safe to set ACK.ResourceSynced condition to true.
-		ackcondition.SetSynced(latest, corev1.ConditionTrue, nil, nil)
+		if ackcondition.Synced(latest) == nil {
+			ackcondition.SetSynced(latest, corev1.ConditionTrue, nil, nil)
+		}
 	}
 	return latest, nil
 }

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -83,8 +83,6 @@ type AWSResourceManager interface {
 	// This method also adds/updates the ConditionTypeReferencesResolved for the
 	// AWSResource.
 	ResolveReferences(context.Context, client.Reader, AWSResource) (AWSResource, error)
-	// IsSynced returns true if a resource is synced.
-	IsSynced(context.Context, AWSResource) (bool, error)
 }
 
 // AWSResourceManagerFactory returns an AWSResourceManager that can be used to


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1133

Description of changes:
* Do not overwrite `ACK.ResourceSynced` condition, if it was being set by ReadOne/Create/Update hook code
* This change will restore existing functionality for asynchronous Create/Update handling until `AWS.ResourceManager.IsSynced` method is implemented. 
* revert the AWSResourceManager.IsSynced method, which can be added after this immediate patch
----

Tested locally with `iam-controller` and `rds-controller`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
