### PR TITLE
Use original status when making api-server `Status.Update` call in adoption reconciler

### DIFF
--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -224,10 +224,16 @@ func (r *adoptionReconciler) Sync(
 	}, described.RuntimeObject()); err != nil {
 		if apierrors.IsNotFound(err) {
 			// If Adopted AWS resource was not found in k8s, create it.
+
+			// Before creation, Keep the copy of original described object
+			// because after the create call, Status gets set to empty
+			describedCopy := described.DeepCopy()
 			if err := r.kc.Create(ctx, described.RuntimeObject()); err != nil {
 				return r.onError(ctx, desired, err)
 			}
-
+			// reset the status of described object to original value before
+			// making the Status Update call
+			described.SetStatus(describedCopy)
 			if err := r.kc.Status().Update(ctx, described.RuntimeObject()); err != nil {
 				return r.onError(ctx, desired, err)
 			}

--- a/pkg/runtime/adoption_reconciler_test.go
+++ b/pkg/runtime/adoption_reconciler_test.go
@@ -108,6 +108,8 @@ func setupMockAwsResource(res *ackmocks.AWSResource, adoptedRes *ackv1alpha1.Ado
 	rmo.On("GetFinalizers").Return(make([]string, 0))
 	rmo.On("GetOwnerReferences").Return(make([]v1.OwnerReference, 0))
 	rmo.On("GetGenerateName").Return("")
+	res.On("DeepCopy").Return(res)
+	res.On("SetStatus", res).Run(func(args mock.Arguments) {})
 }
 
 func setupMockManager(manager *ackmocks.AWSResourceManager, ctx context.Context, res *ackmocks.AWSResource) {
@@ -435,9 +437,13 @@ func assertAWSResourceCreation(
 ) {
 	if expectedCreation {
 		kc.AssertCalled(t, "Create", ctx, res.RuntimeObject())
+		res.AssertCalled(t, "DeepCopy")
+		res.AssertCalled(t, "SetStatus", res)
 		statusWriter.AssertCalled(t, "Update", ctx, res.RuntimeObject())
 	} else {
 		kc.AssertNotCalled(t, "Create", ctx, res.RuntimeObject())
+		res.AssertNotCalled(t, "DeepCopy")
+		res.AssertNotCalled(t, "SetStatus", res)
 		statusWriter.AssertNotCalled(t, "Update", ctx, res.RuntimeObject())
 	}
 }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1161

Description of changes:
* The Status update from AdoptionReconciler was not useful because the Create call before Status.Update was resetting status of the CustomResource.
* Earlier this similar kind of problem was also present in `reconciler.go` and it was fixed by keeping an original copy of Status before making Create/Update calls
* I used the same solution in AdoptionReconciler.

----------

* Discovered this issue while debugging SageMaker ModelPackage adoption test. ModelPackage uses ARN as identifier which needs to be set inside `Status.ACKResourceMetadata.ARN` field of CustomResource.
* Since the Identifier was never getting correctly set, the `ReadOne` call inside `reconciler.go` was failing while reconciling the CustomResource.

--------------

* Validated by running SageMaker end-to-end tests successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
