### PR TITLE
handle requeues after setting Synced condition

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -29,6 +29,8 @@ var (
 	NotManagedReason  = "This resource already exists but is not managed by ACK. " +
 		"To bring the resource under ACK management, you should explicitly adopt " +
 		"the resource by creating a services.k8s.aws/AdoptedResource"
+	NotSyncedMessage = "Resource not synced"
+	SyncedMessage    = "Resource synced successfully"
 )
 
 // Synced returns the Condition in the resource's Conditions collection that is

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -346,20 +346,6 @@ func (r *resourceReconciler) createResource(
 		return nil, err
 	}
 
-	// Once the desired resource is marked as managed (i.e. Finalizer is added
-	// inside the resource metadata and the resource is patched inside etcd), the
-	// patch operation updates the desired resource spec with spec present in
-	// etcd. This means if any references were resolved, they get reset after
-	// the patch call. So we resolve the references again before calling the
-	// rm.Create() method.
-	rlog.Enter("rm.ResolveReferences")
-	resolvedRefDesired, err := rm.ResolveReferences(ctx, r.apiReader, desired)
-	rlog.Exit("rm.ResolveReferences", err)
-	if err != nil {
-		return resolvedRefDesired, err
-	}
-	desired = resolvedRefDesired
-
 	rlog.Enter("rm.Create")
 	latest, err = rm.Create(ctx, desired)
 	rlog.Exit("rm.Create", err)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -343,6 +343,20 @@ func (r *resourceReconciler) createResource(
 		return nil, err
 	}
 
+	// Once the desired resource is marked as managed (i.e. Finalizer is added
+	// inside the resource metadata and the resource is patched inside etcd), the
+	// patch operation updates the desired resource spec with spec present in
+	// etcd. This means if any references were resolved, they get reset after
+	// the patch call. So we resolve the references again before calling the
+	// rm.Create() method.
+	rlog.Enter("rm.ResolveReferences")
+	resolvedRefDesired, err := rm.ResolveReferences(ctx, r.apiReader, desired)
+	rlog.Exit("rm.ResolveReferences", err)
+	if err != nil {
+		return resolvedRefDesired, err
+	}
+	desired = resolvedRefDesired
+
 	rlog.Enter("rm.Create")
 	latest, err = rm.Create(ctx, desired)
 	rlog.Exit("rm.Create", err)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -188,7 +188,11 @@ func (r *resourceReconciler) reconcile(
 		res, _ = rm.ResolveReferences(ctx, r.apiReader, res)
 		return r.deleteResource(ctx, rm, res)
 	}
-	return r.Sync(ctx, rm, res)
+	latest, err := r.Sync(ctx, rm, res)
+	if err != nil {
+		return latest, err
+	}
+	return r.handleRequeues(ctx, latest)
 }
 
 // Sync ensures that the supplied AWSResource's backing API resource
@@ -209,7 +213,7 @@ func (r *resourceReconciler) Sync(
 
 	r.resetConditions(ctx, desired)
 	defer func() {
-		r.ensureConditions(ctx, latest, err)
+		r.ensureConditions(rm, ctx, latest, err)
 	}()
 
 	isAdopted := IsAdopted(desired)
@@ -244,18 +248,9 @@ func (r *resourceReconciler) Sync(
 	// Attempt to late initialize the resource. If there are no fields to
 	// late initialize, this operation will be a no-op.
 	if latest, err = r.lateInitializeResource(ctx, rm, latest); err != nil {
-		// TODO(vijtrip2): move this condition handling to generated
-		// AWSResourceManager.LateInitialize() method
-
-		// Whenever late initialization fails for a resource, set ACK.ResourceSynced
-		// condition explicitly to "False"
-		// Setting this explicitly to False is required because ACK.ResourceSynced
-		// condition can be True due to successful Create/Update call OR no
-		// Create/Update call in reconciler loop
-		ackcondition.SetSynced(latest, corev1.ConditionFalse, nil, nil)
 		return latest, err
 	}
-	return r.handleRequeues(ctx, latest)
+	return latest, nil
 }
 
 // resetConditions strips the supplied resource of all objects in its
@@ -279,6 +274,7 @@ func (r *resourceReconciler) resetConditions(
 // ensureConditions examines the supplied resource's collection of Condition
 // objects and ensures that an ACK.ResourceSynced condition is present.
 func (r *resourceReconciler) ensureConditions(
+	rm acktypes.AWSResourceManager,
 	ctx context.Context,
 	res acktypes.AWSResource,
 	reconcileErr error,
@@ -292,12 +288,13 @@ func (r *resourceReconciler) ensureConditions(
 	exit := rlog.Trace("r.ensureConditions")
 	defer exit(err)
 
-	if syncedCond := ackcondition.Synced(res); syncedCond == nil {
-		rlog.Debug("resource missing ACK.ResourceSynced condition")
-		// only the resource manager will know whether the resource is in a
-		// stable sync state. Even if we got no error back from the
-		// create/update operations, we can only set this to Unknown.
-		condStatus := corev1.ConditionUnknown
+	// If the ACK.ResourceSynced condition is not set using the custom hooks,
+	// determine the Synced condition using "rm.IsSynced" method
+	if ackcondition.Synced(res) == nil {
+		condStatus := corev1.ConditionFalse
+		if synced, _ := rm.IsSynced(ctx, res); synced {
+			condStatus = corev1.ConditionTrue
+		}
 		if reconcileErr != nil {
 			if reconcileErr == ackerr.Terminal {
 				// A terminal condition by its very nature indicates a stable state

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -165,7 +165,7 @@ func TestReconcilerUpdate(t *testing.T) {
 		conditions := args.Get(0).([]*ackv1alpha1.Condition)
 		assert.Equal(t, 1, len(conditions))
 		cond := conditions[0]
-		assert.Equal(t, cond.Type, ackv1alpha1.ConditionTypeResourceSynced)
+		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
 		assert.Equal(t, corev1.ConditionTrue, cond.Status)
 	})
 
@@ -241,7 +241,7 @@ func TestReconcilerUpdate_ResourceNotSynced(t *testing.T) {
 		conditions := args.Get(0).([]*ackv1alpha1.Condition)
 		assert.Equal(t, 1, len(conditions))
 		cond := conditions[0]
-		assert.Equal(t, cond.Type, ackv1alpha1.ConditionTypeResourceSynced)
+		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
 		// Synced condition is false because rm.IsSynced() method returns
 		// False
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
@@ -320,9 +320,9 @@ func TestReconcilerUpdate_IsSyncedError(t *testing.T) {
 		conditions := args.Get(0).([]*ackv1alpha1.Condition)
 		assert.Equal(t, 1, len(conditions))
 		cond := conditions[0]
-		assert.Equal(t, cond.Type, ackv1alpha1.ConditionTypeResourceSynced)
+		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
 		// Synced condition is false because rm.IsSynced() method returns
-		// False
+		// an error
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 	})
 
@@ -469,7 +469,7 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInSpec(t *testing.T) {
 			}
 
 			hasSynced = true
-			assert.Equal(condition.Status, corev1.ConditionTrue)
+			assert.Equal(corev1.ConditionTrue, condition.Status)
 		}
 		assert.True(hasSynced)
 	})
@@ -609,7 +609,7 @@ func TestReconcilerUpdate_ErrorInLateInitialization(t *testing.T) {
 			// Even though mocked IsSynced method returns (true, nil),
 			// the reconciler error from late initialization correctly causes
 			// the ResourceSynced condition to be False
-			assert.Equal(condition.Status, corev1.ConditionFalse)
+			assert.Equal(corev1.ConditionFalse, condition.Status)
 		}
 		assert.True(hasSynced)
 	})
@@ -694,8 +694,8 @@ func TestReconcilerUpdate_ResourceNotManaged(t *testing.T) {
 			}
 
 			hasTerminal = true
-			assert.Equal(condition.Message, terminalCondition.Message)
-			assert.Equal(condition.Reason, terminalCondition.Reason)
+			assert.Equal(terminalCondition.Message, condition.Message)
+			assert.Equal(terminalCondition.Reason, condition.Reason)
 		}
 		assert.True(hasTerminal)
 	}).Once()
@@ -711,8 +711,8 @@ func TestReconcilerUpdate_ResourceNotManaged(t *testing.T) {
 			}
 
 			hasTerminal = true
-			assert.Equal(condition.Message, terminalCondition.Message)
-			assert.Equal(condition.Reason, terminalCondition.Reason)
+			assert.Equal(terminalCondition.Message, condition.Message)
+			assert.Equal(terminalCondition.Reason, condition.Reason)
 		}
 		assert.True(hasTerminal)
 
@@ -724,7 +724,7 @@ func TestReconcilerUpdate_ResourceNotManaged(t *testing.T) {
 			hasSynced = true
 			// The terminal error from reconciler correctly causes
 			// the ResourceSynced condition to be True
-			assert.Equal(condition.Status, corev1.ConditionTrue)
+			assert.Equal(corev1.ConditionTrue, condition.Status)
 		}
 		assert.True(hasSynced)
 	})
@@ -782,10 +782,10 @@ func TestReconcilerUpdate_ResolveReferencesError(t *testing.T) {
 		conditions := args.Get(0).([]*ackv1alpha1.Condition)
 		assert.Equal(t, 1, len(conditions))
 		cond := conditions[0]
-		assert.Equal(t, cond.Type, ackv1alpha1.ConditionTypeResourceSynced)
+		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
 		// The non-terminal reconciler error causes the ResourceSynced
 		// condition to be False
-		assert.Equal(t, cond.Status, corev1.ConditionFalse)
+		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/1186

Description of changes:
* Call `handleRequeues` method after setting the `ACK.ResourceSynced` condition
* Use `AWSResourceManager.IsSynced` method to determine the `ACK.ResourceSynced` condition
* Only set `ACK.ResourceSynced` condition inside `ensureConditions` function when the condition is originally missing
* Update existing unit-tests to include `rm.IsSynced()` call and Add a new unit-test when `rm.IsSynced` returns false
------

* Also tested locally using Sagemaker controller, whose e2e tests verify that SyncedCondition is properly set in success and failure scenarios. This ensures there is no breakage in existing functionality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
