### PR TITLE
Resolve references again after adding the finalizer

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -355,6 +355,14 @@ func (r *resourceReconciler) createResource(
 		return nil, err
 	}
 
+	rlog.Enter("rm.ResolveReferences")
+	resolvedRefDesired, err := rm.ResolveReferences(ctx, r.apiReader, desired)
+	rlog.Exit("rm.ResolveReferences", err)
+	if err != nil {
+		return resolvedRefDesired, err
+	}
+	desired = resolvedRefDesired
+
 	rlog.Enter("rm.Create")
 	latest, err = rm.Create(ctx, desired)
 	rlog.Exit("rm.Create", err)


### PR DESCRIPTION
Issue [#1187](https://github.com/aws-controllers-k8s/community/issues/1187)

Description of changes:
* Resolve References again after adding the finalizer to the resource. More details about the approach and alternate solution are mentioned in issue [#1187](https://github.com/aws-controllers-k8s/community/issues/1187)
* The `kc.Patch` call when adding a finalizer, updates the desired object with the etcd copy and resets all the resolved references.
* Resolving the references again helps in constructing the complete CreateRequest
* Added Unit test for the Create scenario in `reconciler_test.go` file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
