### PR TITLE
Centralize synced condition handling inside ensureConditions method

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -440,13 +440,6 @@ func (r *resourceReconciler) updateResource(
 			return latest, err
 		}
 		rlog.Info("updated resource")
-	} else {
-		// If there is no delta between desired state and latest state, and
-		// ACK.ResourceSynced condition is not already set, it is
-		// safe to set ACK.ResourceSynced condition to true.
-		if ackcondition.Synced(latest) == nil {
-			ackcondition.SetSynced(latest, corev1.ConditionTrue, nil, nil)
-		}
 	}
 	return latest, nil
 }


### PR DESCRIPTION
Description of changes:
* Since `ACK.ResourceSynced` condition is now handled inside `ensureConditions` so we do not need to explicitly set `ACK.ResourceSynced` condition as `True` when there is no delta between desired and latest spec.
* This will fix the bug when `ACK.ResourceSynced` condition should be determined using `rm.IsSynced` method inside `ensureConditions`, but `updateResource` prematurely sets the `ACK.ResourceSynced` condition to true due to no delta between desired & latest Spec and `ensureConditions` method does not override the condition.
* ensureConditions method does not override the Synced condition status because there are still many controllers that set the Synced condition using custom hooks.
* No unit-test changes needed. Existing test covers this case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
