### PR TITLE
Resolve references again only when resource is patched with finalizer

### DIFF
--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -139,7 +139,7 @@ func managerFactoryMocks(
 	return rmf, rd
 }
 
-func TestReconcilerCreate_CheckReferencesResolveTwice(t *testing.T) {
+func TestReconcilerCreate_UnManagedResource_CheckReferencesResolveTwice(t *testing.T) {
 	require := require.New(t)
 
 	ctx := context.TODO()
@@ -183,6 +183,8 @@ func TestReconcilerCreate_CheckReferencesResolveTwice(t *testing.T) {
 	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
 
 	rm.On("LateInitialize", ctx, latest).Return(latest, nil)
+	// Mark the resource as NotManaged before the Create call
+	rd.On("IsManaged", desired).Return(false).Once()
 	rd.On("IsManaged", desired).Return(true)
 	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
 	rd.On("Delta", latest, latest).Return(ackcompare.NewDelta())
@@ -203,6 +205,81 @@ func TestReconcilerCreate_CheckReferencesResolveTwice(t *testing.T) {
 	// Make sure references are resolved twice for the resource creation.
 	// Once before ReadOne call and one after marking the resource managed.
 	rm.AssertNumberOfCalls(t, "ResolveReferences", 2)
+	rm.AssertCalled(t, "ResolveReferences", ctx, nil, desired)
+	rm.AssertCalled(t, "ReadOne", ctx, desired)
+	rm.AssertCalled(t, "Create", ctx, desired)
+	// No changes to metadata or spec so Patch on the object shouldn't be done
+	kc.AssertNotCalled(t, "Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch"))
+	// Only the HandleReconcilerError wrapper function ever calls patchResourceStatus
+	kc.AssertNotCalled(t, "Status")
+	rm.AssertCalled(t, "LateInitialize", ctx, latest)
+	rm.AssertCalled(t, "IsSynced", ctx, latest)
+}
+
+func TestReconcilerCreate_ManagedResource_CheckReferencesResolveOnce(t *testing.T) {
+	require := require.New(t)
+
+	ctx := context.TODO()
+	arn := ackv1alpha1.AWSResourceName("mybook-arn")
+
+	desired, _, _ := resourceMocks()
+	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+
+	ids := &ackmocks.AWSResourceIdentifiers{}
+	ids.On("ARN").Return(&arn)
+
+	latest, latestRTObj, _ := resourceMocks()
+	latest.On("Identifiers").Return(ids)
+
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
+		assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	})
+
+	rm := &ackmocks.AWSResourceManager{}
+	rm.On("ResolveReferences", ctx, nil, desired).Return(
+		desired, nil,
+	).Once()
+	rm.On("ReadOne", ctx, desired).Return(
+		latest, ackerr.NotFound,
+	).Once()
+	rm.On("ReadOne", ctx, latest).Return(
+		latest, nil,
+	)
+	rm.On("Create", ctx, desired).Return(
+		latest, nil,
+	)
+	rm.On("IsSynced", ctx, latest).Return(true, nil)
+	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
+
+	rm.On("LateInitialize", ctx, latest).Return(latest, nil)
+	rd.On("IsManaged", desired).Return(true)
+	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
+	rd.On("Delta", latest, latest).Return(ackcompare.NewDelta())
+
+	r, kc := reconcilerMocks(rmf)
+
+	// pointers returned from "client.MergeFrom" fails the equality check during
+	// assertion even when parameters inside two objects are same.
+	// hence we use mock.AnythingOfType parameter to assert patch call
+	kc.On("Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch")).Return(nil)
+
+	// With the above mocks and below assertions, we check that if we got a
+	// NotFound error return from `AWSResourceManager.ReadOne()` that we end
+	// up calling the AWSResourceManager.Create() call in the Reconciler.Sync()
+	// method,
+	_, err := r.Sync(ctx, rm, desired)
+	require.Nil(err)
+	// Make sure references are resolved once for the resource creation when
+	// the resource is already managed
+	rm.AssertNumberOfCalls(t, "ResolveReferences", 1)
 	rm.AssertCalled(t, "ResolveReferences", ctx, nil, desired)
 	rm.AssertCalled(t, "ReadOne", ctx, desired)
 	rm.AssertCalled(t, "Create", ctx, desired)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1234

Description of changes:

* Keeps existing functionality but adds a condition to check for finalizer before adding the finalizer and resolving the references again.
* If the resource is not getting patched again, there is no need for resolving the references again
* Adds Unit test cases for Create behavior of both managed and unmanaged resources

----

* Original issue [#1187](https://github.com/aws-controllers-k8s/community/issues/1187) explaining why references are resolved again during resource creation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
