### PR TITLE
Add a retry mechanism for `ReadOne` calls in `rm.createResource`

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -38,6 +38,7 @@ License version 2.0, we include the full text of the package's License below.
 * `k8s.io/client-go`
 * `sigs.k8s.io/controller-runtime`
 * `sigs.k8s.io/controller-tools`
+* `github.com/cenkalti/backoff`
 
 ### github.com/aws/aws-sdk-go
 
@@ -1388,3 +1389,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+# github.com/cenkalti/backoff
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Subdependencies: N/A

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.42.0
+	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.5
 	github.com/itchyny/gojq v0.12.6

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
+github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -58,6 +58,9 @@ var (
 	// SecretNotFound is returned if specified kubernetes secret is not found.
 	SecretNotFound = fmt.Errorf(
 		"kubernetes secret not found")
+	// ReadOneFailedAfterCreate is returned if a ReadOne call fails right after
+	// a create operation.
+	ReadOneFailedAfterCreate = fmt.Errorf("ReadOne call failed after a Create operation")
 )
 
 // AWSError returns the type conversion for the supplied error to an aws-sdk-go
@@ -72,6 +75,12 @@ func AWSError(err error) (awserr.Error, bool) {
 func AWSRequestFailure(err error) (awserr.RequestFailure, bool) {
 	awsRF, ok := err.(awserr.RequestFailure)
 	return awsRF, ok
+}
+
+// NewReadOneFailAfterCreate takes a number of attempts and returns a
+// ReadOneFailedAfterCreate error if multiple ReadOne calls fails.
+func NewReadOneFailAfterCreate(numAttempts int) error {
+	return fmt.Errorf("%w: number of attempts: %d", ReadOneFailedAfterCreate, numAttempts)
 }
 
 // HTTPStatusCode returns the HTTP status code from the supplied error by


### PR DESCRIPTION
Issue #, if available:

Description of changes:

In some rare cases and with some specific AWS APIs, calling `ReadOne`
right after a `rm.Create` can return a `NotFound` error. We want to
retry calling `rm.ReadOne` in hopes of receiving a correct response.

This patch adds a backoff/retry mechanism around `ReadOne` call in
`rm.createResource`.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
