### PR TITLE
Add `New` method to `TerminalError`

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -92,6 +92,10 @@ type TerminalError struct {
 	err error
 }
 
+func (e TerminalError) New(terminalError error) *TerminalError {
+	return &TerminalError{err: terminalError}
+}
+
 func (e TerminalError) Error() string {
 	if e.err == nil {
 		return ""


### PR DESCRIPTION
This method helps to throw terminal error from the controller.

Controller code can throw errors like

```
	if *latestStatus == "create-failed" {
		return nil, ackerr.TerminalError.New(errors.New("cluster cannot be updated as its status is not 'available'."))
	}
```

Code generator changes - https://github.com/aws-controllers-k8s/code-generator/pull/318

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
