### PR TITLE
Update `NewTerminalError` method to be not instance method

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -92,7 +92,7 @@ type TerminalError struct {
 	err error
 }
 
-func (e TerminalError) New(terminalError error) *TerminalError {
+func NewTerminalError(terminalError error) *TerminalError {
 	return &TerminalError{err: terminalError}
 }
 


### PR DESCRIPTION
Cannot instantiate without this change. 
