### PR TITLE
Skip resource FE reconciler if CRD not present

### DIFF
--- a/pkg/runtime/service_controller.go
+++ b/pkg/runtime/service_controller.go
@@ -243,13 +243,16 @@ func (c *serviceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg
 		if err := rec.BindControllerManager(mgr); err != nil {
 			return err
 		}
-		rd := rmf.ResourceDescriptor()
-		feRec := NewFieldExportReconcilerForAWSResource(c, exporterLogger, cfg, c.metrics, cache, rd)
-		if err := feRec.BindControllerManager(mgr); err != nil {
-			return err
-		}
 		c.reconcilers = append(c.reconcilers, rec)
-		c.resourceFieldExportReconcilers = append(c.resourceFieldExportReconcilers, feRec)
+
+		if exporterInstalled {
+			rd := rmf.ResourceDescriptor()
+			feRec := NewFieldExportReconcilerForAWSResource(c, exporterLogger, cfg, c.metrics, cache, rd)
+			if err := feRec.BindControllerManager(mgr); err != nil {
+				return err
+			}
+			c.resourceFieldExportReconcilers = append(c.resourceFieldExportReconcilers, feRec)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1287

Description of changes:
Skips creating the FE reconciler for AWS resources if the field export CRD is not present in the cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
