### PR TITLE
add Delta.DifferentExcept() method

### DIFF
--- a/pkg/compare/delta_test.go
+++ b/pkg/compare/delta_test.go
@@ -59,8 +59,34 @@ func TestDifferentAt(t *testing.T) {
 	d.Add("Baz.Y", a.Baz.Y, b.Baz.Y)
 	require.True(d.DifferentAt("Baz"))
 	require.True(d.DifferentAt("Baz.Y"))
-	require.False(d.DifferentAt("Y")) // there is no diff for top-level field "Y"
-	require.False(d.DifferentAt("Bar")) // diff exists but it was not added to Delta
+	require.False(d.DifferentAt("Y"))       // there is no diff for top-level field "Y"
+	require.False(d.DifferentAt("Bar"))     // diff exists but it was not added to Delta
 	require.False(d.DifferentAt("Baz.Y.Z")) // subject length exceeds length of diff Path
-	require.False(d.DifferentAt("Baz.Z"))  // matches Path top-level field but not sub-field
+	require.False(d.DifferentAt("Baz.Z"))   // matches Path top-level field but not sub-field
+}
+
+func TestDifferentExcept(t *testing.T) {
+	require := require.New(t)
+
+	a := Foo{
+		Bar: "a_bar",
+		Baz: Baz{
+			Y: "a_baz_y",
+		},
+	}
+	b := Foo{
+		Bar: "b_bar",
+		Baz: Baz{
+			Y: "b_baz_y",
+		},
+	}
+
+	d := compare.NewDelta()
+	d.Add("", a, nil)
+	require.False(d.DifferentExcept(""))
+
+	d = compare.NewDelta()
+	d.Add("Baz.Y", a.Baz.Y, b.Baz.Y)
+	require.True(d.DifferentExcept("Bar"))    // there is a difference that is *not* Bar
+	require.False(d.DifferentExcept("Baz.Y")) // there is *not* a different that is *not* Bar
 }


### PR DESCRIPTION
I need the ability to detect whether there are any differences in a
resource's fields *other than* a particular one. Basically, in doing the
tagging work for DBInstance, I came across a problem where we were
calling the ModifyDBInstance API call even though there were no changes
to DBInstance Spec fields *other than* the Tags collection.

So, I need to add the following in an sdk_update_pre_build_request
template for DBInstance:

```go
if delta.DifferentAt("Spec.Tags") {
     if err = rm.SyncTags(ctx, desired, latest); err != nil {
         return nil, err
     }
}
if !delta.DifferentExcept("Spec.Tags") {
     // We don't want to proceed to call the ModifyDBInstance API since
     // no other resource fields have changed.
     return desired, nil
}
```

This PR adds the `delta.DifferentExcept()` implementation to enable the
above code.

Issue aws-controllers-k8s/community#1276

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
