### PR TITLE
update for default resource tags

### DIFF
--- a/mocks/pkg/types/service_controller.go
+++ b/mocks/pkg/types/service_controller.go
@@ -40,6 +40,20 @@ func (_m *ServiceController) BindControllerManager(_a0 manager.Manager, _a1 conf
 	return r0
 }
 
+// GetMetadata provides a mock function with given fields:
+func (_m *ServiceController) GetMetadata() types.ServiceControllerMetadata {
+	ret := _m.Called()
+
+	var r0 types.ServiceControllerMetadata
+	if rf, ok := ret.Get(0).(func() types.ServiceControllerMetadata); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(types.ServiceControllerMetadata)
+	}
+
+	return r0
+}
+
 // GetReconcilers provides a mock function with given fields:
 func (_m *ServiceController) GetReconcilers() []types.AWSResourceReconciler {
 	ret := _m.Called()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,13 @@ const (
 	envVarAWSRegion          = "AWS_REGION"
 )
 
+var (
+	defaultResourceTags = []string{
+		"services.k8s.aws/controller-version=%CONTROLLER_VERSION%",
+		"services.k8s.aws/namespace=%K8S_NAMESPACE%",
+	}
+)
+
 // Config contains configuration otpions for ACK service controllers
 type Config struct {
 	MetricsAddr              string
@@ -104,7 +111,7 @@ func (cfg *Config) BindFlags() {
 	)
 	flag.StringSliceVar(
 		&cfg.ResourceTags, flagResourceTags,
-		[]string{},
+		defaultResourceTags,
 		"Configures the ACK service controller to always set key/value pairs tags on resources that it manages.",
 	)
 	flag.StringVar(

--- a/pkg/runtime/service_controller_test.go
+++ b/pkg/runtime/service_controller_test.go
@@ -40,10 +40,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	mocks "github.com/aws-controllers-k8s/runtime/mocks/pkg/types"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
-
-	mocks "github.com/aws-controllers-k8s/runtime/mocks/pkg/types"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 var (
@@ -147,7 +147,7 @@ func TestServiceController(t *testing.T) {
 	reg := ackrt.NewRegistry()
 	reg.RegisterResourceManagerFactory(rmf)
 
-	vi := ackrt.VersionInfo{
+	vi := acktypes.VersionInfo{
 		GitCommit:  "test-commit",
 		GitVersion: "test-version",
 		BuildDate:  "now",

--- a/pkg/types/service_controller.go
+++ b/pkg/types/service_controller.go
@@ -24,6 +24,28 @@ import (
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 )
 
+// VersionInfo contains information about the version of the runtime and
+// service controller in use
+type VersionInfo struct {
+	// GitCommit is the SHA1 commit for the service controller's code
+	GitCommit string
+	// GitVersion is the latest Git tag from the service controller's code
+	GitVersion string
+	// BuildDate is a timestamp of when the code was built
+	BuildDate string
+}
+
+type ServiceControllerMetadata struct {
+	VersionInfo
+	// ServiceAlias is a string with the alias of the service API, e.g. "s3"
+	ServiceAlias string
+	// ServiceAPIGroup is a string with the full DNS-correct API group that
+	// this service controller manages, e.g. "s3.services.k8s.aws"
+	ServiceAPIGroup string
+	// ServiceEndpointsID is a string with the service API's EndpointsID, e.g. "api.sagemaker"
+	ServiceEndpointsID string
+}
+
 // ServiceController wraps one or more reconcilers (for individual resources in
 // an AWS API) with the upstream common controller-runtime machinery.
 type ServiceController interface {
@@ -64,4 +86,7 @@ type ServiceController interface {
 		ackv1alpha1.AWSResourceName,
 		schema.GroupVersionKind,
 	) (*session.Session, error)
+
+	// GetMetadata returns the metadata associated with the service controller.
+	GetMetadata() ServiceControllerMetadata
 }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1261

Description of changes:
* This PR changes the default ACK resource tags from empty list to []string{"services.k8s.aws/controller-version=%CONTROLLER_VERSION%" ,"services.k8s.aws/namespace=%K8S_NAMESPACE%"}.

* Instead of statically passing the controller release version from release artifacts, i made it a dynamic `%CONTROLLER_VERSION%` variable. The dynamic variable will allow customers to use this variable in their custom tags as well.

* I refactored the various service controller metadata fields into a new `ServiceControllerMetadata` type as well.

Tested locally that the resource tags get resolved as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
