### PR TITLE
refactor tag-format constants to a separate package

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 )
 
 const (
@@ -43,8 +45,13 @@ const (
 
 var (
 	defaultResourceTags = []string{
-		"services.k8s.aws/controller-version=%CONTROLLER_VERSION%",
-		"services.k8s.aws/namespace=%K8S_NAMESPACE%",
+		fmt.Sprintf("services.k8s.aws/controller-version=%s-%s",
+			acktags.ServiceAliasTagFormat,
+			acktags.ControllerVersionTagFormat,
+		),
+		fmt.Sprintf("services.k8s.aws/namespace=%s",
+			acktags.NamespaceTagFormat,
+		),
 	}
 )
 

--- a/pkg/runtime/tags.go
+++ b/pkg/runtime/tags.go
@@ -19,6 +19,7 @@ import (
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackconfig "github.com/aws-controllers-k8s/runtime/pkg/config"
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
@@ -29,11 +30,7 @@ type resolveTagFormat func(rtclient.Object, acktypes.ServiceControllerMetadata) 
 const (
 	// MissingImageTagValue is the placeholder value when ACK controller
 	// image tag(release semver) cannot be determined.
-	MissingImageTagValue       = "unknown"
-	ServiceAliasTagFormat      = "%CONTROLLER_SERVICE%"
-	ControllerVersionTagFormat = "%CONTROLLER_VERSION%"
-	NamespaceTagFormat         = "%K8S_NAMESPACE%"
-	ResourceNameTagFormat      = "%K8S_RESOURCE_NAME%"
+	MissingImageTagValue = "unknown"
 )
 
 // ACKResourceTagFormats is map of ACK resource tag formats to it's
@@ -43,14 +40,14 @@ const (
 // resolveTagFormat function and expandTagValue() method will start
 // expanding the new resource tag format.
 var ACKResourceTagFormats = map[string]resolveTagFormat{
-	ServiceAliasTagFormat: func(
+	acktags.ServiceAliasTagFormat: func(
 		obj rtclient.Object,
 		md acktypes.ServiceControllerMetadata,
 	) string {
 		return md.ServiceAlias
 	},
 
-	ControllerVersionTagFormat: func(
+	acktags.ControllerVersionTagFormat: func(
 		obj rtclient.Object,
 		md acktypes.ServiceControllerMetadata,
 	) string {
@@ -65,14 +62,14 @@ var ACKResourceTagFormats = map[string]resolveTagFormat{
 		return controllerImageTag
 	},
 
-	NamespaceTagFormat: func(
+	acktags.NamespaceTagFormat: func(
 		obj rtclient.Object,
 		md acktypes.ServiceControllerMetadata,
 	) string {
 		return obj.GetNamespace()
 	},
 
-	ResourceNameTagFormat: func(
+	acktags.ResourceNameTagFormat: func(
 		obj rtclient.Object,
 		md acktypes.ServiceControllerMetadata,
 	) string {

--- a/pkg/runtime/tags_test.go
+++ b/pkg/runtime/tags_test.go
@@ -1,15 +1,29 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package runtime_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/aws-controllers-k8s/runtime/pkg/config"
+	"github.com/stretchr/testify/assert"
 
 	mocks "github.com/aws-controllers-k8s/runtime/mocks/controller-runtime/pkg/client"
+	"github.com/aws-controllers-k8s/runtime/pkg/config"
 	"github.com/aws-controllers-k8s/runtime/pkg/runtime"
-	"github.com/aws-controllers-k8s/runtime/pkg/types"
-	"github.com/stretchr/testify/assert"
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 func TestGetDefaultTags(t *testing.T) {
@@ -20,9 +34,9 @@ func TestGetDefaultTags(t *testing.T) {
 
 	cfg := config.Config{}
 
-	md := types.ServiceControllerMetadata{
+	md := acktypes.ServiceControllerMetadata{
 		ServiceAlias: "s3",
-		VersionInfo: types.VersionInfo{
+		VersionInfo: acktypes.VersionInfo{
 			GitVersion: "v0.0.10",
 		},
 	}
@@ -56,14 +70,14 @@ func TestGetDefaultTags(t *testing.T) {
 	cfg.ResourceTags = []string{
 		"foo=bar",
 		fmt.Sprintf("services.k8s.aws/controller-version=%s-%s",
-			runtime.ServiceAliasTagFormat,
-			runtime.ControllerVersionTagFormat,
+			acktags.ServiceAliasTagFormat,
+			acktags.ControllerVersionTagFormat,
 		),
 		fmt.Sprintf("services.k8s.aws/namespace=%s",
-			runtime.NamespaceTagFormat,
+			acktags.NamespaceTagFormat,
 		),
 		fmt.Sprintf("services.k8s.aws/name=%s",
-			runtime.ResourceNameTagFormat,
+			acktags.ResourceNameTagFormat,
 		),
 	}
 	expandedTags = runtime.GetDefaultTags(&cfg, &obj, md)

--- a/pkg/tags/tag_format.go
+++ b/pkg/tags/tag_format.go
@@ -1,0 +1,21 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tags
+
+const (
+	ServiceAliasTagFormat      = "%CONTROLLER_SERVICE%"
+	ControllerVersionTagFormat = "%CONTROLLER_VERSION%"
+	NamespaceTagFormat         = "%K8S_NAMESPACE%"
+	ResourceNameTagFormat      = "%K8S_RESOURCE_NAME%"
+)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1261

Description of changes:
* Using tag-format constants inside `pkg/config/config.go` rather than hardcoded strings
* Move the tag format definition into a separate package to avoid cyclic import between `pkg/config` & `pkg/runtime`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
