### PR TITLE
add new AWSResourceManager.EnsureControllerTags() method

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -78,6 +78,20 @@ func (_m *AWSResourceManager) Delete(_a0 context.Context, _a1 types.AWSResource)
 	return r0, r1
 }
 
+// EnsureControllerTags provides a mock function with given fields: _a0, _a1
+func (_m *AWSResourceManager) EnsureControllerTags(_a0 context.Context, _a1 types.AWSResource) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // IsSynced provides a mock function with given fields: _a0, _a1
 func (_m *AWSResourceManager) IsSynced(_a0 context.Context, _a1 types.AWSResource) (bool, error) {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -175,6 +175,12 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 	if err != nil {
 		return ctrlrt.Result{}, err
 	}
+	rlog.Enter("rm.EnsureControllerTags")
+	err = rm.EnsureControllerTags(ctx, desired)
+	rlog.Exit("rm.EnsureControllerTags", err)
+	if err != nil {
+		return ctrlrt.Result{}, err
+	}
 	latest, err := r.reconcile(ctx, rm, desired)
 	return r.HandleReconcileError(ctx, desired, latest, err)
 }

--- a/pkg/tags/resource_tags.go
+++ b/pkg/tags/resource_tags.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tags
+
+// ResourceTags represents the AWS tags which will be added to the AWS resource.
+// Inside aws-sdk-go, Tags are represented using multiple types, Ex: map of
+// string, list of structs etc...
+// ResourceTags type will be used as a hub/mediator to merge tags represented
+// using different types.
+type ResourceTags struct {
+	Tags map[string]string
+}
+
+// NewResourceTags returns ResourceTags with empty tags
+func NewResourceTags() ResourceTags {
+	return ResourceTags{make(map[string]string)}
+}
+
+// NewResourceTagsFrom creates ResourceTags using the tags passed
+// inside the parameter
+func NewResourceTagsFrom(tags map[string]string) ResourceTags {
+	return ResourceTags{tags}
+}
+
+// Merge merges the tags between two ResourceTags.
+// If a tag-key is already present inside the original ResourceTag('rt'), it
+// does not get overwritten.
+func (rt *ResourceTags) Merge(other ResourceTags) {
+	if other.Tags != nil && len(other.Tags) > 0 {
+		// Initialize if the Tags field is nil
+		if rt.Tags == nil {
+			rt.Tags = make(map[string]string)
+		}
+		// Add all the tags which are not already present
+		for tk, tv := range other.Tags {
+			if _, found := rt.Tags[tk]; !found {
+				rt.Tags[tk] = tv
+			}
+		}
+	}
+}

--- a/pkg/tags/resource_tags_test.go
+++ b/pkg/tags/resource_tags_test.go
@@ -1,0 +1,67 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tags_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+)
+
+func TestNewResourceTags(t *testing.T) {
+	assert := assert.New(t)
+	rt := acktags.NewResourceTags()
+	assert.NotNil(rt)
+	assert.Empty(rt.Tags)
+
+	tags := map[string]string{"tk": "tv"}
+	rt = acktags.NewResourceTagsFrom(tags)
+	assert.NotNil(rt)
+	assert.NotEmpty(rt.Tags)
+	assert.Equal("tv", rt.Tags["tk"])
+}
+
+func TestNewResourceTagsFrom(t *testing.T) {
+	assert := assert.New(t)
+
+	tags := map[string]string{"tk": "tv"}
+	rt := acktags.NewResourceTagsFrom(tags)
+	assert.NotNil(rt)
+	assert.NotEmpty(rt.Tags)
+	assert.Equal("tv", rt.Tags["tk"])
+}
+
+func TestResourceTags_Merge_NilTags(t *testing.T) {
+	assert := assert.New(t)
+
+	rt1 := acktags.NewResourceTagsFrom(nil)
+	rt2 := acktags.NewResourceTagsFrom(map[string]string{"tk": "tv", "tk2": "tv2"})
+	rt1.Merge(rt2)
+	assert.Equal("tv", rt1.Tags["tk"])
+	assert.Equal("tv2", rt1.Tags["tk2"])
+	assert.Equal(2, len(rt1.Tags))
+}
+
+func TestResourceTags_Merge(t *testing.T) {
+	assert := assert.New(t)
+
+	rt1 := acktags.NewResourceTagsFrom(map[string]string{"tk": "tv"})
+	rt2 := acktags.NewResourceTagsFrom(map[string]string{"tk": "tv1", "tk2": "tv2"})
+	rt1.Merge(rt2)
+	assert.Equal("tv", rt1.Tags["tk"])
+	assert.Equal("tv2", rt1.Tags["tk2"])
+	assert.Equal(2, len(rt1.Tags))
+}

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -85,6 +85,11 @@ type AWSResourceManager interface {
 	ResolveReferences(context.Context, client.Reader, AWSResource) (AWSResource, error)
 	// IsSynced returns true if a resource is synced.
 	IsSynced(context.Context, AWSResource) (bool, error)
+	// EnsureControllerTags ensures that ACK controller tags are present
+	// inside AWSResource.
+	// If AWSResource does not support tags, only then controller tags will
+	// be missing from AWSResource after this method call.
+	EnsureControllerTags(context.Context, AWSResource) error
 }
 
 // AWSResourceManagerFactory returns an AWSResourceManager that can be used to


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1261

Description of changes:
* Adds new `AWSResourceManager.EnsureControllerTags()` method
* `EnsureControllerTags` method will be called before invoking `reconcile` method to update the desired resource with the ACK controller tags
* This change also introduces a new `ResourceTags` shape, which will be used as mediator/hub to merge AWS tags represented using different go types.
* code-generator will generate the logic of conversion to/from `ResourceTags`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
