### PR TITLE
Update rm.EnsureTags to accept controller metadata

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -78,13 +78,13 @@ func (_m *AWSResourceManager) Delete(_a0 context.Context, _a1 types.AWSResource)
 	return r0, r1
 }
 
-// EnsureTags provides a mock function with given fields: _a0, _a1
-func (_m *AWSResourceManager) EnsureTags(_a0 context.Context, _a1 types.AWSResource) error {
-	ret := _m.Called(_a0, _a1)
+// EnsureTags provides a mock function with given fields: _a0, _a1, _a2
+func (_m *AWSResourceManager) EnsureTags(_a0 context.Context, _a1 types.AWSResource, _a2 types.ServiceControllerMetadata) error {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource) error); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource, types.ServiceControllerMetadata) error); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -234,7 +234,7 @@ func (r *resourceReconciler) Sync(
 	desired = resolvedRefDesired
 
 	rlog.Enter("rm.EnsureTags")
-	err = rm.EnsureTags(ctx, desired)
+	err = rm.EnsureTags(ctx, desired, r.sc.GetMetadata())
 	rlog.Exit("rm.EnsureTags", err)
 	if err != nil {
 		return desired, err
@@ -386,7 +386,7 @@ func (r *resourceReconciler) createResource(
 		// because they are not persisted in etcd. So we again ensure
 		// that tags are present before performing the create operation.
 		rlog.Enter("rm.EnsureTags")
-		err = rm.EnsureTags(ctx, desired)
+		err = rm.EnsureTags(ctx, desired, r.sc.GetMetadata())
 		rlog.Exit("rm.EnsureTags", err)
 		if err != nil {
 			return desired, err

--- a/pkg/runtime/tags.go
+++ b/pkg/runtime/tags.go
@@ -82,11 +82,11 @@ func GetDefaultTags(
 	config *ackconfig.Config,
 	obj rtclient.Object,
 	md acktypes.ServiceControllerMetadata,
-) map[string]string {
+) acktags.Tags {
+	defaultTags := acktags.NewTags()
 	if obj == nil || config == nil || len(config.ResourceTags) == 0 {
-		return nil
+		return defaultTags
 	}
-	var populatedTags = make(map[string]string)
 	for _, tagKeyVal := range config.ResourceTags {
 		keyVal := strings.Split(tagKeyVal, "=")
 		if keyVal == nil || len(keyVal) != 2 {
@@ -97,9 +97,9 @@ func GetDefaultTags(
 		if key == "" || val == "" {
 			continue
 		}
-		populatedTags[key] = expandTagValue(val, obj, md)
+		defaultTags[key] = expandTagValue(val, obj, md)
 	}
-	return populatedTags
+	return defaultTags
 }
 
 // expandTagValue returns the tag value after expanding all the ACKResourceTag

--- a/pkg/runtime/tags_test.go
+++ b/pkg/runtime/tags_test.go
@@ -42,13 +42,13 @@ func TestGetDefaultTags(t *testing.T) {
 	}
 
 	// nil config
-	assert.Nil(runtime.GetDefaultTags(nil, &obj, md))
+	assert.Empty(runtime.GetDefaultTags(nil, &obj, md))
 
 	// nil object
-	assert.Nil(runtime.GetDefaultTags(&cfg, nil, md))
+	assert.Empty(runtime.GetDefaultTags(&cfg, nil, md))
 
 	// no resource tags
-	assert.Nil(runtime.GetDefaultTags(&cfg, &obj, md))
+	assert.Empty(runtime.GetDefaultTags(&cfg, &obj, md))
 
 	// ill formed tags
 	cfg.ResourceTags = []string{"foobar"}

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -92,7 +92,7 @@ type AWSResourceManager interface {
 	// added to the existing resource tags without overriding them.
 	// If the AWSResource does not support tags, only then the controller tags
 	// will not be added to the AWSResource.
-	EnsureTags(context.Context, AWSResource) error
+	EnsureTags(context.Context, AWSResource, ServiceControllerMetadata) error
 }
 
 // AWSResourceManagerFactory returns an AWSResourceManager that can be used to


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1261

Description of changes:
* Pass `acktypes.ServiceControllerMetadata` parameter to `rm.EnsureTags` so that tag formats like `%CONTROLLER_VERSION%` can be resolved.
* ACK controller metadata required to expand tag formats is present inside `ServiceControllerMetadata` object.
* Change the return type of `ackrt.GetDefaultTags` method from `map[string]string` to `acktags.Tags` .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
