### PR TITLE
Revert "Patch metadata and spec when handling errors (#92)"

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -860,8 +860,6 @@ func (r *resourceReconciler) HandleReconcileError(
 	err error,
 ) (ctrlrt.Result, error) {
 	if ackcompare.IsNotNil(latest) {
-		// Create a copy so we don't override the spec
-		latestCopy := latest.DeepCopy()
 		// The reconciliation loop may have returned an error, but if latest is
 		// not nil, there may be some changes available in the CR's Status
 		// struct (example: Conditions), and we want to make sure we save those
@@ -875,17 +873,12 @@ func (r *resourceReconciler) HandleReconcileError(
 		//
 		// TODO(jaypipes): We ignore error handling here but I don't know if
 		// there is a more robust way to handle failures in the patch operation
-		_ = r.patchResourceStatus(ctx, desired, latestCopy)
+		_ = r.patchResourceStatus(ctx, desired, latest)
 	}
 	if err == nil || err == ackerr.Terminal {
 		return ctrlrt.Result{}, nil
 	}
 	rlog := ackrtlog.FromContext(ctx)
-
-	// Ensure that we are patching any changes to the annotations/metadata and
-	// the Spec that may have been set by the resource manager's successful
-	// Create call above.
-	_ = r.patchResourceMetadataAndSpec(ctx, desired, latest)
 
 	var requeueNeededAfter *requeue.RequeueNeededAfter
 	if errors.As(err, &requeueNeededAfter) {


### PR DESCRIPTION
This reverts commit de2738269396ec6e038b101745cd23c06555cc9a.

Description of changes:
Adding a patch in `HandleReconcileError` caused subsequent test failures in the EKS controller, and ultimately did not fix the issue in the RDS controller. This PR is to revert that change so that we can roll back to a known good state for any other controllers that may have been affected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
