### PR TITLE
Update logger to ISO8601

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,7 @@ var (
 			acktags.NamespaceTagFormat,
 		),
 	}
+	defaultLogLevel = zapcore.InfoLevel
 )
 
 // Config contains configuration otpions for ACK service controllers
@@ -131,18 +132,13 @@ func (cfg *Config) BindFlags() {
 
 // SetupLogger initializes the logger used in the service controller
 func (cfg *Config) SetupLogger() {
-	var lvl zapcore.LevelEnabler
-
-	switch cfg.LogLevel {
-	case "debug":
-		lvl = zapcore.DebugLevel
-	default:
-		lvl = zapcore.InfoLevel
-	}
+	lvl := defaultLogLevel
+	lvl.UnmarshalText([]byte(cfg.LogLevel))
 
 	zapOptions := zap.Options{
 		Development: cfg.EnableDevelopmentLogging,
 		Level:       lvl,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	ctrlrt.SetLogger(zap.New(zap.UseFlagOptions(&zapOptions)))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,7 +115,7 @@ func (cfg *Config) BindFlags() {
 	flag.StringVar(
 		&cfg.LogLevel, flagLogLevel,
 		"info",
-		"The log level. Default is info. We use logr interface which only supports info and debug level",
+		"The log level. The default is info. The options are: debug, info, warn, error, dpanic, panic, fatal",
 	)
 	flag.StringSliceVar(
 		&cfg.ResourceTags, flagResourceTags,


### PR DESCRIPTION
Description of changes:
The current logs are written in Unix nanosecond timestamp, but are awkwardly represented with scientific notation (eg. `1.6559302967712986e+09`). These timestamps are almost impossible for a human to read and because of their notation are also not suitable for log ingestion.

This pull request updates the logger to use the ISO8601 standard format (eg. `2022-06-23T23:19:35.040Z`). This should make it much clearer to developers (and end users) how much time elapsed between events. ISO8601 is a standard format for timestamps that is properly supported by log ingest tools, as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
