### PR TITLE
Add force-s3-path-style option

### DIFF
--- a/mocks/pkg/types/service_controller.go
+++ b/mocks/pkg/types/service_controller.go
@@ -86,13 +86,13 @@ func (_m *ServiceController) GetResourceManagerFactories() map[string]types.AWSR
 	return r0
 }
 
-// NewSession provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *ServiceController) NewSession(_a0 v1alpha1.AWSRegion, _a1 *string, _a2 v1alpha1.AWSResourceName, _a3 schema.GroupVersionKind) (*session.Session, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3)
+// NewSession provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4
+func (_m *ServiceController) NewSession(_a0 v1alpha1.AWSRegion, _a1 *string, _a2 bool, _a3 v1alpha1.AWSResourceName, _a4 schema.GroupVersionKind) (*session.Session, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4)
 
 	var r0 *session.Session
-	if rf, ok := ret.Get(0).(func(v1alpha1.AWSRegion, *string, v1alpha1.AWSResourceName, schema.GroupVersionKind) *session.Session); ok {
-		r0 = rf(_a0, _a1, _a2, _a3)
+	if rf, ok := ret.Get(0).(func(v1alpha1.AWSRegion, *string, bool, v1alpha1.AWSResourceName, schema.GroupVersionKind) *session.Session); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*session.Session)
@@ -100,8 +100,8 @@ func (_m *ServiceController) NewSession(_a0 v1alpha1.AWSRegion, _a1 *string, _a2
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(v1alpha1.AWSRegion, *string, v1alpha1.AWSResourceName, schema.GroupVersionKind) error); ok {
-		r1 = rf(_a0, _a1, _a2, _a3)
+	if rf, ok := ret.Get(1).(func(v1alpha1.AWSRegion, *string, bool, v1alpha1.AWSResourceName, schema.GroupVersionKind) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ const (
 	flagEnableDevLogging     = "enable-development-logging"
 	flagAWSRegion            = "aws-region"
 	flagAWSEndpointURL       = "aws-endpoint-url"
+	flagForceS3PathStyle     = "force-s3-path-style"
 	flagLogLevel             = "log-level"
 	flagResourceTags         = "resource-tags"
 	flagWatchNamespace       = "watch-namespace"
@@ -64,6 +65,7 @@ type Config struct {
 	AccountID                string
 	Region                   string
 	EndpointURL              string
+	ForceS3PathStyle         bool
 	LogLevel                 string
 	ResourceTags             []string
 	WatchNamespace           string
@@ -111,6 +113,11 @@ func (cfg *Config) BindFlags() {
 		"The AWS endpoint URL the service controller will use to create its resources. This is an optional"+
 			" flag that can be used to override the default behaviour of aws-sdk-go that constructs endpoint URLs"+
 			" automatically based on service and region",
+	)
+	flag.BoolVar(
+		&cfg.ForceS3PathStyle, flagForceS3PathStyle,
+		false,
+		"Force communication with the S3 API as path-style",
 	)
 	flag.StringVar(
 		&cfg.LogLevel, flagLogLevel,

--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -114,7 +114,7 @@ func (r *adoptionReconciler) reconcile(ctx context.Context, req ctrlrt.Request) 
 	endpointURL := r.getEndpointURL(res)
 
 	sess, err := r.sc.NewSession(
-		region, &endpointURL, roleARN,
+		region, &endpointURL, r.cfg.ForceS3PathStyle, roleARN,
 		targetDescriptor.EmptyRuntimeObject().GetObjectKind().GroupVersionKind(),
 	)
 	if err != nil {

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -156,7 +156,7 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 	roleARN := r.getRoleARN(acctID)
 	endpointURL := r.getEndpointURL(desired)
 	gvk := desired.RuntimeObject().GetObjectKind().GroupVersionKind()
-	sess, err := r.sc.NewSession(region, &endpointURL, roleARN, gvk)
+	sess, err := r.sc.NewSession(region, &endpointURL, r.cfg.ForceS3PathStyle, roleARN, gvk)
 	if err != nil {
 		return ctrlrt.Result{}, err
 	}
@@ -1015,9 +1015,9 @@ func (r *resourceReconciler) getRoleARN(
 //
 // If the resource has not yet been created, we look for the AWS region
 // in the following order of precedence:
-//  - The resource's `services.k8s.aws/region` annotation, if present
-//  - The resource's Namespace's `services.k8s.aws/region` annotation, if present
-//  - The controller's `--aws-region` CLI flag
+//   - The resource's `services.k8s.aws/region` annotation, if present
+//   - The resource's Namespace's `services.k8s.aws/region` annotation, if present
+//   - The controller's `--aws-region` CLI flag
 func (r *resourceReconciler) getRegion(
 	res acktypes.AWSResource,
 ) ackv1alpha1.AWSRegion {

--- a/pkg/runtime/session.go
+++ b/pkg/runtime/session.go
@@ -35,6 +35,7 @@ const appName = "aws-controllers-k8s"
 func (c *serviceController) NewSession(
 	region ackv1alpha1.AWSRegion,
 	endpointURL *string,
+	forceS3PathStyle bool,
 	assumeRoleARN ackv1alpha1.AWSResourceName,
 	groupVersionKind schema.GroupVersionKind,
 ) (*session.Session, error) {
@@ -42,6 +43,8 @@ func (c *serviceController) NewSession(
 		Region:              aws.String(string(region)),
 		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 	}
+
+	awsCfg.S3ForcePathStyle = aws.Bool(forceS3PathStyle)
 
 	if *endpointURL != "" {
 		endpointServiceResolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {

--- a/pkg/types/service_controller.go
+++ b/pkg/types/service_controller.go
@@ -83,6 +83,7 @@ type ServiceController interface {
 	NewSession(
 		ackv1alpha1.AWSRegion,
 		*string,
+		bool,
 		ackv1alpha1.AWSResourceName,
 		schema.GroupVersionKind,
 	) (*session.Session, error)


### PR DESCRIPTION
Description of changes:

In sdk v1 the config to use path-style interactions for S3, is on the central session config object. This means that we need to expose this setting as a runtime config option as well, as the session construction is centralized across controllers. 

It's (at least to me) not nice to thus have this as config for all rendered controllers, but the definite central aws.Config is really the culprit here, rather than having an interface or sthg. Is this better in v2? not sure...

For sdk v1 this is probably the way forward? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
