### PR TITLE
Regenerate CRDs using controller-gen `v0.9.2`

### DIFF
--- a/config/crd/bases/services.k8s.aws_adoptedresources.yaml
+++ b/config/crd/bases/services.k8s.aws_adoptedresources.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/crd/bases/services.k8s.aws_adoptedresources.yaml
+++ b/config/crd/bases/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: adoptedresources.services.k8s.aws
 spec:
@@ -169,6 +169,7 @@ spec:
                           - name
                           - uid
                           type: object
+                          x-kubernetes-map-type: atomic
                         type: array
                     type: object
                 required:
@@ -223,9 +224,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/services.k8s.aws_fieldexports.yaml
+++ b/config/crd/bases/services.k8s.aws_fieldexports.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/crd/bases/services.k8s.aws_fieldexports.yaml
+++ b/config/crd/bases/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: fieldexports.services.k8s.aws
 spec:
@@ -132,9 +132,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Signed-off-by: Michael Gasch <15986659+embano1@users.noreply.github.com>

Description of changes: When using the Kubernetes `e2e-framework` for testing a CRD setup function fails due to the newline in the two bases CRDs provided by this `runtime`.

The fix is to remove the newlines which should not cause any issues with ACK downstream dependencies, controllers, code-gen, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
