### PR TITLE
Add support for resource-specific resync periods and default drift remediation period

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,7 +161,7 @@ func (cfg *Config) BindFlags() {
 	)
 	flag.IntVar(
 		&cfg.ReconcileDefaultResyncSeconds, flagReconcileDefaultResyncSeconds,
-		60,
+		0,
 		"The default duration, in seconds, to wait before resyncing desired state of custom resources. "+
 			"This value is used if no resource-specific override has been specified. Default is 60 seconds.",
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -163,7 +163,7 @@ func (cfg *Config) BindFlags() {
 		&cfg.ReconcileDefaultResyncSeconds, flagReconcileDefaultResyncSeconds,
 		0,
 		"The default duration, in seconds, to wait before resyncing desired state of custom resources. "+
-			"This value is used if no resource-specific override has been specified. Default is 60 seconds.",
+			"This value is used if no resource-specific override has been specified. Default is 10 hours.",
 	)
 	flag.StringArrayVar(
 		&cfg.ReconcileResourceResyncSeconds, flagReconcileResourceResyncSeconds,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import "testing"
+
+func TestParseReconcileFlagArgument(t *testing.T) {
+	tests := []struct {
+		flagArgument   string
+		expectedKey    string
+		expectedVal    int
+		expectedErr    bool
+		expectedErrMsg string
+	}{
+		// Test valid flag arguments
+		{"key=1", "key", 1, false, ""},
+		{"key=123456", "key", 123456, false, ""},
+		{"key=600", "key", 600, false, ""},
+		{"k=1", "k", 1, false, ""},
+		{"ke_y=123456", "ke_y", 123456, false, ""},
+
+		// Test invalid flag arguments
+		{"key", "", 0, true, "invalid flag argument format: expected key=value"},
+		{"key=", "", 0, true, "missing value in flag argument"},
+		{"=value", "", 0, true, "missing key in flag argument"},
+		{"key=value1=value2", "", 0, true, "invalid flag argument format: expected key=value"},
+		{"key=a", "", 0, true, "invalid value in flag argument: strconv.Atoi: parsing \"a\": invalid syntax"},
+		{"key=-1", "", 0, true, "invalid value in flag argument: expected non-negative integer, got -1"},
+		{"key=-123456", "", 0, true, "invalid value in flag argument: expected non-negative integer, got -123456"},
+		{"key=1.1", "", 0, true, "invalid value in flag argument: strconv.Atoi: parsing \"1.1\": invalid syntax"},
+	}
+	for _, test := range tests {
+		key, val, err := parseReconcileFlagArgument(test.flagArgument)
+		if err != nil && !test.expectedErr {
+			t.Errorf("unexpected error for flag argument '%s': %v", test.flagArgument, err)
+		}
+		if err == nil && test.expectedErr {
+			t.Errorf("expected error for flag argument '%s', got nil", test.flagArgument)
+		}
+		if err != nil && err.Error() != test.expectedErrMsg {
+			t.Errorf("unexpected error message for flag argument '%s': expected '%s', got '%v'", test.flagArgument, test.expectedErrMsg, err)
+		}
+		if key != test.expectedKey {
+			t.Errorf("unexpected key for flag argument '%s': expected '%s', got '%s'", test.flagArgument, test.expectedKey, key)
+		}
+		if val != test.expectedVal {
+			t.Errorf("unexpected value for flag argument '%s': expected %d, got %d", test.flagArgument, test.expectedVal, val)
+		}
+	}
+}

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -1086,11 +1086,12 @@ func (r *resourceReconciler) getEndpointURL(
 // state of custom resources is maintained.
 // It attempts to retrieve the duration from the following sources, in this order:
 // 1. A resource-specific reconciliation resync period specified in the reconciliation resync
-//    configuration map.
+//    configuration map (--reconcile-default-resync-seconds).
 // 2. A resource-specific requeue on success period specified by the resource manager factory.
 //    The resource manager factory is controller-specific, and thus this period is to specified
-//    by controller authors.
+//    by controller authors (using ack-generate).
 // 3. The default reconciliation resync period period specified in the controller binary flags.
+//    (--reconcile-resource-resync-seconds)
 // 4. The default resync period defined in the ACK runtime package. Defined in defaultResyncPeriod
 //    within the same file
 //

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -136,6 +136,7 @@ func managerFactoryMocks(
 
 	rmf := &ackmocks.AWSResourceManagerFactory{}
 	rmf.On("ResourceDescriptor").Return(rd)
+	rmf.On("RequeueOnSuccessSeconds").Return(0)
 
 	reg := ackrt.NewRegistry()
 	reg.RegisterResourceManagerFactory(rmf)

--- a/pkg/runtime/service_controller_test.go
+++ b/pkg/runtime/service_controller_test.go
@@ -143,6 +143,7 @@ func TestServiceController(t *testing.T) {
 
 	rmf := &mocks.AWSResourceManagerFactory{}
 	rmf.On("ResourceDescriptor").Return(rd)
+	rmf.On("RequeueOnSuccessSeconds").Return(0)
 
 	reg := ackrt.NewRegistry()
 	reg.RegisterResourceManagerFactory(rmf)


### PR DESCRIPTION
Part of: https://github.com/aws-controllers-k8s/community/issues/1367

This patch introduces the ability to specify resource-specific resync periods in
the drift remediation configuration, as well as a default drift remediation period
in the controller configuration. The resync period for each reconciler is
determined by trying to retrieve it from the following sources, in this order:

1. A resource-specific period specified in the drift remediation configuration.
2. A resource-specific requeue on success period specified by the resource manager
   factory.
3. The default drift remediation period specified in the controller configuration.
4. The default resync period defined in the ACK runtime package.

This allows users to customize the drift remediation behavior for different
resources as needed, while still providing a fallback option for resources that do
not have a specific period specified.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
