### PR TITLE
Add deletion policy CLI arguments and annotations

### DIFF
--- a/apis/core/v1alpha1/annotations.go
+++ b/apis/core/v1alpha1/annotations.go
@@ -59,4 +59,11 @@ const (
 	// will either use the default behavior	of aws-sdk-go to create endpoints or
 	// aws-endpoint-url if it is set in controller binary flags and environment variables.
 	AnnotationEndpointURL = AnnotationPrefix + "endpoint-url"
+	// AnnotationDeletionPolicy is an annotation whose value is the identifier for the
+	// the deletion policy for the current resource. If this annotation is set
+	// to "delete" the resource manager will delete the AWS resource when the
+	// K8s resource is deleted. If this annotation is set to "retain" the
+	// resource manager will leave the AWS resource intact when the K8s resource
+	// is deleted.
+	AnnotationDeletionPolicy = AnnotationPrefix + "deletion-policy"
 )

--- a/apis/core/v1alpha1/deletion_policy.go
+++ b/apis/core/v1alpha1/deletion_policy.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1alpha1
+
+import "errors"
+
+// DeletionPolicy represents how the ACK reconciler will handle the deletion of
+// a resource. A DeletionPolicy of "delete" will delete the underlying AWS
+// resource, whereas a DeletionPolicy of "retain" will only delete the K8s
+// object leaving the AWS resource intact.
+type DeletionPolicy string
+
+const (
+	DeletionPolicyDelete DeletionPolicy = "delete"
+	DeletionPolicyRetain DeletionPolicy = "retain"
+)
+
+func (e *DeletionPolicy) String() string {
+	return string(*e)
+}
+
+func (e *DeletionPolicy) Set(v string) error {
+	switch v {
+	case string(DeletionPolicyDelete), string(DeletionPolicyRetain):
+		*e = DeletionPolicy(v)
+		return nil
+	default:
+		return errors.New(`invalid DeletionPolicy value`)
+	}
+}
+
+func (e *DeletionPolicy) Type() string {
+	return "DeletionPolicy"
+}

--- a/apis/core/v1alpha1/deletion_policy.go
+++ b/apis/core/v1alpha1/deletion_policy.go
@@ -13,7 +13,9 @@
 
 package v1alpha1
 
-import "errors"
+import (
+	"fmt"
+)
 
 // DeletionPolicy represents how the ACK reconciler will handle the deletion of
 // a resource. A DeletionPolicy of "delete" will delete the underlying AWS
@@ -36,7 +38,7 @@ func (e *DeletionPolicy) Set(v string) error {
 		*e = DeletionPolicy(v)
 		return nil
 	default:
-		return errors.New(`invalid DeletionPolicy value`)
+		return fmt.Errorf("invalid DeletionPolicy value: %s", v)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ import (
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 )
 
@@ -43,6 +44,7 @@ const (
 	flagWatchNamespace         = "watch-namespace"
 	flagEnableWebhookServer    = "enable-webhook-server"
 	flagWebhookServerAddr      = "webhook-server-addr"
+	flagDeletionPolicy         = "deletion-policy"
 	envVarAWSRegion            = "AWS_REGION"
 )
 
@@ -74,6 +76,7 @@ type Config struct {
 	WatchNamespace           string
 	EnableWebhookServer      bool
 	WebhookServerAddr        string
+	DeletionPolicy           ackv1alpha1.DeletionPolicy
 }
 
 // BindFlags defines CLI/runtime configuration options
@@ -144,6 +147,10 @@ func (cfg *Config) BindFlags() {
 		"",
 		"Specific namespace the service controller will watch for object creation from CRD. "+
 			" By default it will listen to all namespaces",
+	)
+	flag.Var(
+		&cfg.DeletionPolicy, flagDeletionPolicy,
+		"The default deletion policy for all resources managed by the controller",
 	)
 }
 
@@ -221,6 +228,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.EnableWebhookServer && cfg.WebhookServerAddr == "" {
 		return errors.New("empty webhook server address")
+	}
+
+	if cfg.DeletionPolicy == "" {
+		cfg.DeletionPolicy = ackv1alpha1.DeletionPolicyDelete
 	}
 	return nil
 }

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -1055,7 +1055,7 @@ func (r *resourceReconciler) getRegion(
 	return ackv1alpha1.AWSRegion(r.cfg.Region)
 }
 
-// getRegion returns the resource's deletion policy based on the default
+// getDeletionPolicy returns the resource's deletion policy based on the default
 // behaviour or any other overriding annotations.
 //
 // We look for the deletion policy in the annotations based on the following

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -202,6 +202,8 @@ func (r *resourceReconciler) reconcile(
 			return r.deleteResource(ctx, rm, res)
 		}
 
+		rlog := ackrtlog.FromContext(ctx)
+		rlog.Info("AWS resource will not be deleted - deletion policy set to retain")
 		if err := r.setResourceUnmanaged(ctx, res); err != nil {
 			return res, err
 		}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/82

Description of changes:
As per the proposal: https://github.com/aws-controllers-k8s/community/pull/1148

Adds support for a new optional CLI argument for the controller binary `--deletion-policy`, supporting `delete` and `retain` as available options. Setting this argument to `delete` leaves the controller as the current default behaviour, whereby it deletes the AWS resource under management before it is removed from the K8s API server. Setting this argument to `retain` modifies the default behaviour, leaving the AWS resources intact (taking no action on them) before removing it from the K8s API server.

Adds support for a new annotation on `Namespace` objects: `{service}.services.k8s.aws/deletion-policy: delete/retain` (where `{service}` is the service alias of the controller eg. `s3`). This annotation overrides the deletion policy behaviour configured for the controller for all resources deployed under the namespace.

Adds support for a new annotation on any ACK resource object: `services.k8s.aws/deletion-policy: delete/retain`. This annotation overrides only the deletion policy behaviour configured for the resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
