### PR TITLE
Add `ackcompare.GetTagsDifference` helper method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,9 +44,11 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/samber/lo v1.37.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samber/lo v1.37.0 h1:XjVcB8g6tgUp8rsPsJ2CvhClfImrpL04YpQHXeHPhRw=
+github.com/samber/lo v1.37.0/go.mod h1:9vaz2O4o8oOnK23pd2TrXufcbdbJIa3b6cstBWKpopA=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -520,6 +522,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/compare/tags.go
+++ b/pkg/compare/tags.go
@@ -1,0 +1,39 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare
+
+import (
+	"github.com/samber/lo"
+
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+)
+
+// GetTagsDifference determines which tags have been added, unchanged or have
+// been removed between the `from` and the `to` inputs. Tags that are in `from`
+// but not in `to` are added to `removed`, whereas tags that are in `to` but not
+// in `from` are added to `added`.
+func GetTagsDifference(from, to acktags.Tags) (added, unchanged, removed acktags.Tags) {
+	// we need to convert the tag tuples to a comparable interface type
+	fromPairs := lo.ToPairs(from)
+	toPairs := lo.ToPairs(to)
+
+	left, right := lo.Difference(fromPairs, toPairs)
+	middle := lo.Intersect(fromPairs, toPairs)
+
+	removed = lo.FromPairs(left)
+	added = lo.FromPairs(right)
+	unchanged = lo.FromPairs(middle)
+
+	return added, unchanged, removed
+}

--- a/pkg/compare/tags_test.go
+++ b/pkg/compare/tags_test.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws-controllers-k8s/runtime/pkg/compare"
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+)
+
+func TestTagsDifference(t *testing.T) {
+	require := require.New(t)
+
+	a := acktags.NewTags()
+	b := acktags.NewTags()
+
+	a["tag1"] = "value1"
+
+	a["tag2"] = "value2"
+	b["tag2"] = "value2"
+
+	b["tag3"] = "value3"
+	b["tag4"] = "value4"
+
+	added, unchanged, removed := compare.GetTagsDifference(a, b)
+
+	require.Len(added, 2)
+	require.Len(unchanged, 1)
+	require.Len(removed, 1)
+
+	require.Contains(added, "tag3")
+	require.Contains(added, "tag4")
+	require.Contains(unchanged, "tag2")
+	require.Contains(removed, "tag1")
+
+	// add test for updating the value of an existing tag
+	a["tag2"] = "oldvalue"
+	b["tag2"] = "newvalue"
+
+	added, unchanged, removed = compare.GetTagsDifference(a, b)
+
+	require.Len(added, 3)
+	require.Len(unchanged, 0)
+	require.Len(removed, 2)
+
+	require.Contains(added, "tag2")
+	require.Equal(added["tag2"], "newvalue")
+}


### PR DESCRIPTION
Extends https://github.com/aws-controllers-k8s/code-generator/pull/399

Description of changes:
Adds a `GetTagsDifference` helper method that can be used to determine which tags should be added and removed based on what they are going "from" and "to" - typically needed for services with `TagResource` and `UntagResource` operations. 

For example:
```go
aTags := ToACKTags(a.ko.Spec.Tags)
bTags := ToACKTags(b.ko.Spec.Tags)

added, _, removed := ackcompare.GetTagsDifference(aTags, bTags)

// optionally, convert back to service Tag type
toAdd := FromACKTags(added)
toRemove := FromACKTags(removed)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
