### PR TITLE
Add `inline` directive to the secret reference

### DIFF
--- a/apis/core/v1alpha1/secret.go
+++ b/apis/core/v1alpha1/secret.go
@@ -20,8 +20,9 @@ import (
 // SecretKeyReference combines a k8s corev1.SecretReference with a
 // specific key within the referred-to Secret
 type SecretKeyReference struct {
-	// Empty JSON tag is required to solve encountered struct field "" without JSON tag  error.
-	k8scorev1.SecretReference `json:""`
+	// Empty JSON tag with "inline" attribute is required to properly inline the
+	// field in JSON output due to k8s apimachinery constraints
+	k8scorev1.SecretReference `json:",inline"`
 	// Key is the key within the secret
 	Key string `json:"key"`
 }


### PR DESCRIPTION
The `SecretKeyReference` uses the `SecretReference` as an embedded stuct. When serializing through the apimachinery's [DefaultUnstructuredConverter](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#pkg-variables) the json `inline` directive needs to be presented so that the fields are inline.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
