### PR TITLE
add inline json tag to embedded struct GroupKind

### DIFF
--- a/apis/core/v1alpha1/identifiers.go
+++ b/apis/core/v1alpha1/identifiers.go
@@ -34,14 +34,20 @@ type AWSIdentifiers struct {
 // resource of a given type (within the same namespace as the custom resource
 // containing this type).
 type NamespacedResource struct {
-	metav1.GroupKind `json:""`
+	// Empty JSON tag with "inline" attribute is required to properly inline the
+	// field in JSON output due to k8s apimachinery constraints
+	// see https://github.com/aws-controllers-k8s/runtime/pull/111
+	metav1.GroupKind `json:",inline"`
 	Name             *string `json:"name"`
 }
 
 // ResourceWithMetadata provides the values necessary to create a
 // Kubernetes resource and override any of its metadata values.
 type ResourceWithMetadata struct {
-	metav1.GroupKind `json:""`
+	// Empty JSON tag with "inline" attribute is required to properly inline the
+	// field in JSON output due to k8s apimachinery constraints
+	// see https://github.com/aws-controllers-k8s/runtime/pull/111
+	metav1.GroupKind `json:",inline"`
 	Metadata         *PartialObjectMeta `json:"metadata,omitempty"`
 }
 


### PR DESCRIPTION
same Issue mentioned in [PR#111](https://github.com/aws-controllers-k8s/runtime/pull/111)

Description of changes:
- add inline json tag on embedded struct GroupKind, make k8s apimachinery UnstructuredConverter works properly with embedded struct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
