### PR TITLE
Add namespace field for AWSResourceReference

### DIFF
--- a/apis/core/v1alpha1/identifiers.go
+++ b/apis/core/v1alpha1/identifiers.go
@@ -65,6 +65,7 @@ type ResourceFieldSelector struct {
 //
 //	from:
 //	  name: my-api
+//	  namespace: api-namespace
 type AWSResourceReferenceWrapper struct {
 	From *AWSResourceReference `json:"from,omitempty"`
 }
@@ -72,5 +73,6 @@ type AWSResourceReferenceWrapper struct {
 // AWSResourceReference provides all the values necessary to reference another
 // k8s resource for finding the identifier(Id/ARN/Name)
 type AWSResourceReference struct {
-	Name *string `json:"name,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	Namespace *string `json:"namespace,omitempty"`
 }


### PR DESCRIPTION
Issue #, if available: Adds the runtime part for https://github.com/aws-controllers-k8s/community/issues/1777

Description of changes:
This PR adds support for a `namespace` key to [AWSResourceReference](https://github.com/aws-controllers-k8s/runtime/blob/main/apis/core/v1alpha1/identifiers.go#L74). This will be used to enable Cross Namespace resource references.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
