### PR TITLE
Configure `klog` to use the ACK runtime logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/api v0.26.8
 	k8s.io/apimachinery v0.26.8
 	k8s.io/client-go v0.26.8
+	k8s.io/klog/v2 v2.80.1
 	sigs.k8s.io/controller-runtime v0.14.5
 )
 
@@ -71,7 +72,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
-	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -205,7 +206,9 @@ func (cfg *Config) SetupLogger() {
 		Level:       lvl,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
-	ctrlrt.SetLogger(zap.New(zap.UseFlagOptions(&zapOptions)))
+	logger := zap.New(zap.UseFlagOptions(&zapOptions))
+	ctrlrt.SetLogger(logger)
+	klog.SetLogger(logger)
 }
 
 // SetAWSAccountID uses sts GetCallerIdentity API to find AWS AccountId and set


### PR DESCRIPTION
This patch addresses an issue where the leaderElection feature was using
`klog/v2` behind the scenes, which was set using a different logger than
the one we use in ACK. This inconsitancy caused the controller to have
two different log styles.

Fortunetly `klog/v2` allow users to set their own loggers, and more
fortunetely `go-logr` is compatible with both `klog` and `zap` the
logger we use in ACK runtime.

Setting `klog` logger results in a more consistant and smooth logging
experience.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
