### PR TITLE
Add `WriteToSecret` method to `Reconciler` interface

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -140,6 +141,43 @@ func (r *reconciler) SecretValueFromReference(
 	}
 
 	return "", ackerr.SecretNotFound
+}
+
+// WriteToSecret writes a value to a Secret given the namespace, name,
+// and key of the Secret
+func (r *reconciler) WriteToSecret(
+	ctx context.Context,
+	sourceValue string,
+	namespace string,
+	name string,
+	key string,
+) error {
+
+	// Get the initial secret
+	nsn := types.NamespacedName{
+		Name: name,
+	}
+	nsn.Namespace = namespace
+
+	secret := &corev1.Secret{}
+	err := r.apiReader.Get(ctx, nsn, secret)
+	if err != nil {
+		return ackerr.SecretNotFound
+	}
+
+	// Update the field
+	patch := client.StrategicMergeFrom(secret.DeepCopy())
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte, 1)
+	}
+	secret.Data[key] = []byte(sourceValue)
+
+	err = r.kc.Patch(ctx, secret, patch)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Reconcile implements `controller-runtime.Reconciler` and handles reconciling

--- a/pkg/types/reconciler.go
+++ b/pkg/types/reconciler.go
@@ -32,4 +32,7 @@ type Reconciler interface {
 	// SecretValueFromReference fetches the value of a Secret given a
 	// SecretKeyReference
 	SecretValueFromReference(context.Context, *v1alpha1.SecretKeyReference) (string, error)
+	// WriteToSecret writes a value to a Secret given the namespace, name,
+	// and key of the Secret
+	WriteToSecret(context.Context, string, string, string, string) error
 }


### PR DESCRIPTION
Description of changes:
WriteToSecret writes a string value to a Secret given the namespace, name, and key of the Secret

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
