### PR TITLE
Introduce scope configuration for internal caches

### DIFF
--- a/pkg/runtime/cache/cache.go
+++ b/pkg/runtime/cache/cache.go
@@ -58,6 +58,14 @@ func init() {
 	)
 }
 
+// Config is used to configure the caches.
+type Config struct {
+	// WatchScope is a list of namespaces to watch for resources
+	WatchScope []string
+	// Ignored is a list of namespaces to ignore
+	Ignored []string
+}
+
 // Caches is used to interact with the different caches
 type Caches struct {
 	// stopCh is a channel use to stop all the
@@ -72,10 +80,10 @@ type Caches struct {
 }
 
 // New instantiate a new Caches object.
-func New(log logr.Logger) Caches {
+func New(log logr.Logger, config Config) Caches {
 	return Caches{
 		Accounts:   NewAccountCache(log),
-		Namespaces: NewNamespaceCache(log),
+		Namespaces: NewNamespaceCache(log, config.WatchScope, config.Ignored),
 	}
 }
 


### PR DESCRIPTION
This patch enhances the runtime internal caches by introducing a
configuration mechanism to tailor their behavior. The caches can now be
configured to watch a specific set of namespaces (instead of the
previous "all or nothing" style).

This is intended to be complete the multi-namspace-watch mode feature.
Now when a user configures a controller to watch a set of namespaces the
ACK runtime caches will also respect that scope.

In addition this commit adds `kube-node-lease` to the set of namespace
ignored by default (This namespace is dedicated to node Leases objects).

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
