### PR TITLE
Support team-id annotation

### DIFF
--- a/apis/core/v1alpha1/annotations.go
+++ b/apis/core/v1alpha1/annotations.go
@@ -35,6 +35,15 @@ const (
 	// TODO(jaypipes): Link to documentation on cross-account resource
 	// management
 	AnnotationOwnerAccountID = AnnotationPrefix + "owner-account-id"
+	// AnnotationTeamID is an annotation whose value is the identifier
+	// for the AWS team ID to manage the resources.  If this annotation
+	// is set on a CR, the Kubernetes user is indicating that the ACK service
+	// controller should create/patch/delete the resource in the specified AWS
+	// role for this team ID. In order for this cross-account resource management
+	// to succeed, the AWS IAM Role that the ACK service controller runs as needs
+	// to have the ability to call the AWS STS::AssumeRole API call and assume an
+	// IAM Role in the target AWS Account.
+	AnnotationTeamID = AnnotationPrefix + "team-id"
 	// AnnotationRegion is an annotation whose value is the identifier for the
 	// the AWS region in which the resources should be created. If this annotation
 	// is set on a CR metadata, that means the user is indicating to the ACK service

--- a/apis/core/v1alpha1/common.go
+++ b/apis/core/v1alpha1/common.go
@@ -19,6 +19,9 @@ type AWSRegion string
 // AWSAccountID represents an AWS account identifier
 type AWSAccountID string
 
+// TeamID represents a team ID identifier.
+type TeamID string
+
 // AWSResourceName represents an AWS Resource Name (ARN)
 type AWSResourceName string
 

--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -122,7 +122,7 @@ func (r *adoptionReconciler) reconcile(ctx context.Context, req ctrlrt.Request) 
 		// annotated with an owner account ID. We need to retrieve the
 		// roleARN from the ConfigMap and properly requeue if the roleARN
 		// is not available.
-		roleARN, err = r.getRoleARN(acctID)
+		roleARN, err = r.getOwnerAccountRoleARN(acctID)
 		if err != nil {
 			ackrtlog.InfoAdoptedResource(r.log, res, fmt.Sprintf("Unable to start adoption reconcilliation %s: %v", acctID, err))
 			// r.getRoleARN errors are not terminal, we should requeue.
@@ -478,14 +478,20 @@ func (r *adoptionReconciler) getEndpointURL(
 	return r.cfg.EndpointURL
 }
 
-// getRoleARN return the Role ARN that should be assumed in order to manage
+// getOwnerAccountRoleARN return the Role ARN that should be assumed in order to manage
 // the resources.
-func (r *adoptionReconciler) getRoleARN(
+func (r *adoptionReconciler) getOwnerAccountRoleARN(
 	acctID ackv1alpha1.AWSAccountID,
 ) (ackv1alpha1.AWSResourceName, error) {
-	roleARN, err := r.cache.Accounts.GetAccountRoleARN(string(acctID))
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+	roleARN, err := r.cache.CARMMaps.GetValue(ackrtcache.OwnerAccountIDPrefix + string(acctID))
+	if err == ackrtcache.ErrCARMConfigMapNotFound || err == ackrtcache.ErrKeyNotFound {
+		// CARM map v2 not defined. Check v1 map.
+		roleARN, err = r.cache.Accounts.GetValue(string(acctID))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("unable to retrieve role ARN from CARM v2 for account %s: %v", acctID, err)
 	}
 	return ackv1alpha1.AWSResourceName(roleARN), nil
 }

--- a/pkg/runtime/cache/account.go
+++ b/pkg/runtime/cache/account.go
@@ -28,48 +28,53 @@ var (
 	// ErrCARMConfigMapNotFound is an error that is returned when the CARM
 	// configmap is not found.
 	ErrCARMConfigMapNotFound = errors.New("CARM configmap not found")
-	// ErrAccountIDNotFound is an error that is returned when the account ID
+	// ErrKeyNotFound is an error that is returned when the account ID
 	// is not found in the CARM configmap.
-	ErrAccountIDNotFound = errors.New("account ID not found in CARM configmap")
-	// ErrEmptyRoleARN is an error that is returned when the role ARN is empty
+	ErrKeyNotFound = errors.New("key not found in CARM configmap")
+	// ErrEmptyValue is an error that is returned when the role ARN is empty
 	// in the CARM configmap.
-	ErrEmptyRoleARN = errors.New("role ARN is empty in CARM configmap")
+	ErrEmptyValue = errors.New("role value is empty in CARM configmap")
 )
 
 const (
 	// ACKRoleAccountMap is the name of the configmap map object storing
 	// all the AWS Account IDs associated with their AWS Role ARNs.
 	ACKRoleAccountMap = "ack-role-account-map"
+
+	// ACKCARMMapV2 is the name of the v2 CARM map.
+	// It stores the mapping for:
+	// - Account ID to the AWS role ARNs.
+	ACKCARMMapV2 = "ack-carm-map"
 )
 
-// AccountCache is responsible for caching the CARM configmap
+// CARMMap is responsible for caching the CARM configmap
 // data. It is listening to all the events related to the CARM map and
 // make the changes accordingly.
-type AccountCache struct {
+type CARMMap struct {
 	sync.RWMutex
 	log              logr.Logger
-	roleARNs         map[string]string
+	data             map[string]string
 	configMapCreated bool
 }
 
-// NewAccountCache instanciate a new AccountCache.
-func NewAccountCache(log logr.Logger) *AccountCache {
-	return &AccountCache{
+// NewCARMMapCache instanciate a new CARMMap.
+func NewCARMMapCache(log logr.Logger) *CARMMap {
+	return &CARMMap{
 		log:              log.WithName("cache.account"),
-		roleARNs:         make(map[string]string),
+		data:             make(map[string]string),
 		configMapCreated: false,
 	}
 }
 
-// resourceMatchACKRoleAccountConfigMap verifies if a resource is
+// resourceMatchCARMConfigMap verifies if a resource is
 // the CARM configmap. It verifies the name, namespace and object type.
-func resourceMatchACKRoleAccountsConfigMap(raw interface{}) bool {
+func resourceMatchCARMConfigMap(raw interface{}, name string) bool {
 	object, ok := raw.(*corev1.ConfigMap)
-	return ok && object.ObjectMeta.Name == ACKRoleAccountMap
+	return ok && object.ObjectMeta.Name == name
 }
 
 // Run instantiate a new SharedInformer for ConfigMaps and runs it to begin processing items.
-func (c *AccountCache) Run(clientSet kubernetes.Interface, stopCh <-chan struct{}) {
+func (c *CARMMap) Run(name string, clientSet kubernetes.Interface, stopCh <-chan struct{}) {
 	c.log.V(1).Info("Starting shared informer for accounts cache", "targetConfigMap", ACKRoleAccountMap)
 	informer := informersv1.NewConfigMapInformer(
 		clientSet,
@@ -79,33 +84,33 @@ func (c *AccountCache) Run(clientSet kubernetes.Interface, stopCh <-chan struct{
 	)
 	informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			if resourceMatchACKRoleAccountsConfigMap(obj) {
+			if resourceMatchCARMConfigMap(obj, name) {
 				cm := obj.(*corev1.ConfigMap)
 				object := cm.DeepCopy()
 				// To avoid multiple mutex locks, we are updating the cache
 				// and the configmap existence flag in the same function.
 				configMapCreated := true
-				c.updateAccountRoleData(configMapCreated, object.Data)
+				c.updateData(configMapCreated, object.Data)
 				c.log.V(1).Info("created account config map", "name", cm.ObjectMeta.Name)
 			}
 		},
 		UpdateFunc: func(orig, desired interface{}) {
-			if resourceMatchACKRoleAccountsConfigMap(desired) {
+			if resourceMatchCARMConfigMap(desired, name) {
 				cm := desired.(*corev1.ConfigMap)
 				object := cm.DeepCopy()
 				//TODO(a-hilaly): compare data checksum before updating the cache
-				c.updateAccountRoleData(true, object.Data)
+				c.updateData(true, object.Data)
 				c.log.V(1).Info("updated account config map", "name", cm.ObjectMeta.Name)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			if resourceMatchACKRoleAccountsConfigMap(obj) {
+			if resourceMatchCARMConfigMap(obj, name) {
 				cm := obj.(*corev1.ConfigMap)
 				newMap := make(map[string]string)
 				// To avoid multiple mutex locks, we are updating the cache
 				// and the configmap existence flag in the same function.
 				configMapCreated := false
-				c.updateAccountRoleData(configMapCreated, newMap)
+				c.updateData(configMapCreated, newMap)
 				c.log.V(1).Info("deleted account config map", "name", cm.ObjectMeta.Name)
 			}
 		},
@@ -113,33 +118,33 @@ func (c *AccountCache) Run(clientSet kubernetes.Interface, stopCh <-chan struct{
 	go informer.Run(stopCh)
 }
 
-// GetAccountRoleARN queries the AWS accountID associated Role ARN
+// GetValue queries the value
 // from the cached CARM configmap. It will return an error if the
-// configmap is not found, the accountID is not found or the role ARN
+// configmap is not found, the key is not found or the value
 // is empty.
 //
 // This function is thread safe.
-func (c *AccountCache) GetAccountRoleARN(accountID string) (string, error) {
+func (c *CARMMap) GetValue(key string) (string, error) {
 	c.RLock()
 	defer c.RUnlock()
 
 	if !c.configMapCreated {
 		return "", ErrCARMConfigMapNotFound
 	}
-	roleARN, ok := c.roleARNs[accountID]
+	roleARN, ok := c.data[key]
 	if !ok {
-		return "", ErrAccountIDNotFound
+		return "", ErrKeyNotFound
 	}
 	if roleARN == "" {
-		return "", ErrEmptyRoleARN
+		return "", ErrEmptyValue
 	}
 	return roleARN, nil
 }
 
-// updateAccountRoleData updates the CARM map. This function is thread safe.
-func (c *AccountCache) updateAccountRoleData(exist bool, data map[string]string) {
+// updateData updates the CARM map. This function is thread safe.
+func (c *CARMMap) updateData(exist bool, data map[string]string) {
 	c.Lock()
 	defer c.Unlock()
-	c.roleARNs = data
+	c.data = data
 	c.configMapCreated = exist
 }

--- a/pkg/runtime/cache/account_test.go
+++ b/pkg/runtime/cache/account_test.go
@@ -64,13 +64,13 @@ func TestAccountCache(t *testing.T) {
 	fakeLogger := ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&zapOptions))
 
 	// initlizing account cache
-	accountCache := ackrtcache.NewAccountCache(fakeLogger)
+	accountCache := ackrtcache.NewCARMMapCache(fakeLogger)
 	stopCh := make(chan struct{})
-	accountCache.Run(k8sClient, stopCh)
+	accountCache.Run(ackrtcache.ACKRoleAccountMap, k8sClient, stopCh)
 
 	// Before creating the configmap, the accountCache should error for any
 	// GetAccountRoleARN call.
-	_, err := accountCache.GetAccountRoleARN(testAccount1)
+	_, err := accountCache.GetValue(testAccount1)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
@@ -90,12 +90,12 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test with non existing account
-	_, err = accountCache.GetAccountRoleARN("random-account-not-exist")
+	_, err = accountCache.GetValue("random-account-not-exist")
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
 	// Test with existing account
-	_, err = accountCache.GetAccountRoleARN(testAccount1)
+	_, err = accountCache.GetValue(testAccount1)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
@@ -114,17 +114,17 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test with non existing account
-	_, err = accountCache.GetAccountRoleARN("random-account-not-exist")
+	_, err = accountCache.GetValue("random-account-not-exist")
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrAccountIDNotFound)
+	require.Equal(t, err, ackrtcache.ErrKeyNotFound)
 
 	// Test with existing account - but role ARN is empty
-	_, err = accountCache.GetAccountRoleARN(testAccount3)
+	_, err = accountCache.GetValue(testAccount3)
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrEmptyRoleARN)
+	require.Equal(t, err, ackrtcache.ErrEmptyValue)
 
 	// Test with existing account
-	roleARN, err := accountCache.GetAccountRoleARN(testAccount1)
+	roleARN, err := accountCache.GetValue(testAccount1)
 	require.Nil(t, err)
 	require.Equal(t, roleARN, testAccountARN1)
 
@@ -144,21 +144,21 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test with non existing account
-	_, err = accountCache.GetAccountRoleARN("random-account-not-exist")
+	_, err = accountCache.GetValue("random-account-not-exist")
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrAccountIDNotFound)
+	require.Equal(t, err, ackrtcache.ErrKeyNotFound)
 
 	// Test that account was removed
-	_, err = accountCache.GetAccountRoleARN(testAccount3)
+	_, err = accountCache.GetValue(testAccount3)
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrAccountIDNotFound)
+	require.Equal(t, err, ackrtcache.ErrKeyNotFound)
 
 	// Test with existing account
-	roleARN, err = accountCache.GetAccountRoleARN(testAccount1)
+	roleARN, err = accountCache.GetValue(testAccount1)
 	require.Nil(t, err)
 	require.Equal(t, roleARN, testAccountARN1)
 
-	roleARN, err = accountCache.GetAccountRoleARN(testAccount2)
+	roleARN, err = accountCache.GetValue(testAccount2)
 	require.Nil(t, err)
 	require.Equal(t, roleARN, testAccountARN2)
 
@@ -172,15 +172,15 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test that accounts ware removed
-	_, err = accountCache.GetAccountRoleARN(testAccount1)
+	_, err = accountCache.GetValue(testAccount1)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
-	_, err = accountCache.GetAccountRoleARN(testAccount2)
+	_, err = accountCache.GetValue(testAccount2)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
-	_, err = accountCache.GetAccountRoleARN(testAccount3)
+	_, err = accountCache.GetValue(testAccount3)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 }

--- a/pkg/runtime/cache/cache.go
+++ b/pkg/runtime/cache/cache.go
@@ -43,6 +43,9 @@ const (
 	// caching system not to set up resyncs with an authoritative state source
 	// (i.e. a Kubernetes API server) on a periodic basis.
 	informerResyncPeriod = 0 * time.Second
+
+	// The prefix for owner account ID in the v2 CARM map.
+	OwnerAccountIDPrefix = "owner-account-id/"
 )
 
 // ackSystemNamespace is the namespace in which we look up ACK system
@@ -73,7 +76,10 @@ type Caches struct {
 	stopCh chan struct{}
 
 	// Accounts cache
-	Accounts *AccountCache
+	Accounts *CARMMap
+
+	// CARMMaps v2 cache
+	CARMMaps *CARMMap
 
 	// Namespaces cache
 	Namespaces *NamespaceCache
@@ -82,7 +88,8 @@ type Caches struct {
 // New instantiate a new Caches object.
 func New(log logr.Logger, config Config) Caches {
 	return Caches{
-		Accounts:   NewAccountCache(log),
+		Accounts:   NewCARMMapCache(log),
+		CARMMaps:   NewCARMMapCache(log),
 		Namespaces: NewNamespaceCache(log, config.WatchScope, config.Ignored),
 	}
 }
@@ -91,7 +98,10 @@ func New(log logr.Logger, config Config) Caches {
 func (c Caches) Run(clientSet kubernetes.Interface) {
 	stopCh := make(chan struct{})
 	if c.Accounts != nil {
-		c.Accounts.Run(clientSet, stopCh)
+		c.Accounts.Run(ACKRoleAccountMap, clientSet, stopCh)
+	}
+	if c.CARMMaps != nil {
+		c.CARMMaps.Run(ACKCARMMapV2, clientSet, stopCh)
 	}
 	if c.Namespaces != nil {
 		c.Namespaces.Run(clientSet, stopCh)

--- a/pkg/runtime/cache/cache.go
+++ b/pkg/runtime/cache/cache.go
@@ -46,6 +46,9 @@ const (
 
 	// The prefix for owner account ID in the v2 CARM map.
 	OwnerAccountIDPrefix = "owner-account-id/"
+
+	// The prefix for owner team ID in the v2 CARM map.
+	TeamIDPrefix = "team-id/"
 )
 
 // ackSystemNamespace is the namespace in which we look up ACK system

--- a/pkg/runtime/cache/namespace.go
+++ b/pkg/runtime/cache/namespace.go
@@ -32,6 +32,8 @@ type namespaceInfo struct {
 	defaultRegion string
 	// services.k8s.aws/owner-account-id Annotation
 	ownerAccountID string
+	// services.k8s.aws/team-id Annotation
+	teamID string
 	// services.k8s.aws/endpoint-url Annotation
 	endpointURL string
 	// {service}.services.k8s.aws/deletion-policy Annotations (keyed by service)
@@ -52,6 +54,14 @@ func (n *namespaceInfo) getOwnerAccountID() string {
 		return ""
 	}
 	return n.ownerAccountID
+}
+
+// getTeamID returns the namespace team-id
+func (n *namespaceInfo) getTeamID() string {
+	if n == nil {
+		return ""
+	}
+	return n.teamID
 }
 
 // getEndpointURL returns the namespace Endpoint URL
@@ -182,6 +192,16 @@ func (c *NamespaceCache) GetOwnerAccountID(namespace string) (string, bool) {
 	return "", false
 }
 
+// GetTeamID returns the team-id if it exists
+func (c *NamespaceCache) GetTeamID(namespace string) (string, bool) {
+	info, ok := c.getNamespaceInfo(namespace)
+	if ok {
+		a := info.getTeamID()
+		return a, a != ""
+	}
+	return "", false
+}
+
 // GetEndpointURL returns the endpoint URL if it exists
 func (c *NamespaceCache) GetEndpointURL(namespace string) (string, bool) {
 	info, ok := c.getNamespaceInfo(namespace)
@@ -224,6 +244,10 @@ func (c *NamespaceCache) setNamespaceInfoFromK8sObject(ns *corev1.Namespace) {
 	OwnerAccountID, ok := nsa[ackv1alpha1.AnnotationOwnerAccountID]
 	if ok {
 		nsInfo.ownerAccountID = OwnerAccountID
+	}
+	TeamID, ok := nsa[ackv1alpha1.AnnotationTeamID]
+	if ok {
+		nsInfo.teamID = TeamID
 	}
 	EndpointURL, ok := nsa[ackv1alpha1.AnnotationEndpointURL]
 	if ok {

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -190,7 +190,7 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 		// annotated with an owner account ID. We need to retrieve the
 		// roleARN from the ConfigMap and properly requeue if the roleARN
 		// is not available.
-		roleARN, err = r.getRoleARN(acctID)
+		roleARN, err = r.getOwnerAccountRoleARN(acctID)
 		if err != nil {
 			// TODO(a-hilaly): Refactor all the reconcile function to make it
 			// easier to understand and maintain.
@@ -1040,15 +1040,22 @@ func (r *resourceReconciler) getOwnerAccountID(
 	return controllerAccountID, false
 }
 
-// getRoleARN return the Role ARN that should be assumed in order to manage
+// getOwnerAccountRoleARN return the Role ARN that should be assumed in order to manage
 // the resources.
-func (r *resourceReconciler) getRoleARN(
+func (r *resourceReconciler) getOwnerAccountRoleARN(
 	acctID ackv1alpha1.AWSAccountID,
 ) (ackv1alpha1.AWSResourceName, error) {
-	roleARN, err := r.cache.Accounts.GetAccountRoleARN(string(acctID))
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+	roleARN, err := r.cache.CARMMaps.GetValue(ackrtcache.OwnerAccountIDPrefix + string(acctID))
+	if err == ackrtcache.ErrCARMConfigMapNotFound || err == ackrtcache.ErrKeyNotFound {
+		// CARM map v2 not defined. Check v1 map.
+		roleARN, err = r.cache.Accounts.GetValue(string(acctID))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("unable to retrieve role ARN from CARM v2 for account %s: %v", acctID, err)
 	}
+
 	return ackv1alpha1.AWSResourceName(roleARN), nil
 }
 

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -176,6 +177,10 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 	// will be reflected in the context.
 	ctx = context.WithValue(ctx, ackrtlog.ContextKey, rlog)
 
+	// If a user specified a namespace with team-id annotation,
+	// we need to get the role and set the accout ID to that role.
+	teamID := r.getTeamID(desired)
+
 	// If a user has specified a namespace that is annotated with the
 	// an owner account ID, we need an appropriate role ARN to assume
 	// in order to perform the reconciliation. The roles ARN are typically
@@ -183,22 +188,29 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 	// If the ConfigMap is not created, or not populated with an
 	// accountID to roleARN mapping, we need to properly requeue with a
 	// helpful message to the user.
-	var roleARN ackv1alpha1.AWSResourceName
 	acctID, needCARMLookup := r.getOwnerAccountID(desired)
-	if needCARMLookup {
-		// This means that the user is specifying a namespace that is
-		// annotated with an owner account ID. We need to retrieve the
-		// roleARN from the ConfigMap and properly requeue if the roleARN
-		// is not available.
-		roleARN, err = r.getOwnerAccountRoleARN(acctID)
+
+	var roleARN ackv1alpha1.AWSResourceName
+	if teamID != "" {
+		roleARN, err = r.getTeamRoleARN(teamID)
 		if err != nil {
-			// TODO(a-hilaly): Refactor all the reconcile function to make it
-			// easier to understand and maintain.
-			reason := err.Error()
-			latest := desired.DeepCopy()
-			// set ResourceSynced condition to false with proper error message
-			condition.SetSynced(latest, corev1.ConditionFalse, &condition.UnavailableIAMRoleMessage, &reason)
-			return r.HandleReconcileError(ctx, desired, latest, requeue.NeededAfter(err, roleARNNotAvailableRequeueDelay))
+			return r.handleCacheError(ctx, err, desired)
+		}
+		parsedARN, err := arn.Parse(string(roleARN))
+		if err != nil {
+			return ctrlrt.Result{}, fmt.Errorf("failed to parsed role ARN %q from namespace annotation: %v", roleARN, err)
+		}
+		acctID = ackv1alpha1.AWSAccountID(parsedARN.AccountID)
+	} else {
+		if needCARMLookup {
+			// This means that the user is specifying a namespace that is
+			// annotated with an owner account ID or team ID. We need to retrieve the
+			// roleARN from the ConfigMap and properly requeue if the roleARN
+			// is not available.
+			roleARN, err = r.getOwnerAccountRoleARN(acctID)
+			if err != nil {
+				return r.handleCacheError(ctx, err, desired)
+			}
 		}
 	}
 	region := r.getRegion(desired)
@@ -224,6 +236,20 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 	}
 	latest, err := r.reconcile(ctx, rm, desired)
 	return r.HandleReconcileError(ctx, desired, latest, err)
+}
+
+func (r *resourceReconciler) handleCacheError(
+	ctx context.Context,
+	err error,
+	desired acktypes.AWSResource,
+) (ctrlrt.Result, error) {
+	// TODO(a-hilaly): Refactor all the reconcile function to make it
+	// easier to understand and maintain.
+	reason := err.Error()
+	latest := desired.DeepCopy()
+	// set ResourceSynced condition to false with proper error message
+	condition.SetSynced(latest, corev1.ConditionFalse, &condition.UnavailableIAMRoleMessage, &reason)
+	return r.HandleReconcileError(ctx, desired, latest, requeue.NeededAfter(err, roleARNNotAvailableRequeueDelay))
 }
 
 // reconcile either cleans up a deleted resource or ensures that the supplied
@@ -1040,8 +1066,21 @@ func (r *resourceReconciler) getOwnerAccountID(
 	return controllerAccountID, false
 }
 
-// getOwnerAccountRoleARN return the Role ARN that should be assumed in order to manage
-// the resources.
+// getTeamID gets the team-id from the namespace annotation.
+func (r *resourceReconciler) getTeamID(
+	res acktypes.AWSResource,
+) ackv1alpha1.TeamID {
+	// look for team ID in the namespace annotations
+	namespace := res.MetaObject().GetNamespace()
+	namespacedTeamID, ok := r.cache.Namespaces.GetTeamID(namespace)
+	if ok {
+		return ackv1alpha1.TeamID(namespacedTeamID)
+	}
+	return ackv1alpha1.TeamID("")
+}
+
+// getRoleARN return the Role ARN that should be assumed for accoutn ID
+// in order to manage the resources.
 func (r *resourceReconciler) getOwnerAccountRoleARN(
 	acctID ackv1alpha1.AWSAccountID,
 ) (ackv1alpha1.AWSResourceName, error) {
@@ -1054,6 +1093,19 @@ func (r *resourceReconciler) getOwnerAccountRoleARN(
 		}
 	} else if err != nil {
 		return "", fmt.Errorf("unable to retrieve role ARN from CARM v2 for account %s: %v", acctID, err)
+	}
+
+	return ackv1alpha1.AWSResourceName(roleARN), nil
+}
+
+// getTeamRoleARN return the Role ARN that should be assumed for a team ID
+// in order to manage the resources.
+func (r *resourceReconciler) getTeamRoleARN(
+	teamID ackv1alpha1.TeamID,
+) (ackv1alpha1.AWSResourceName, error) {
+	roleARN, err := r.cache.CARMMaps.GetValue(ackrtcache.TeamIDPrefix + string(teamID))
+	if err == ackrtcache.ErrCARMConfigMapNotFound || err == ackrtcache.ErrKeyNotFound {
+		return "", fmt.Errorf("unable to retrieve role ARN from CARM v2 for account %s: %v", teamID, err)
 	}
 
 	return ackv1alpha1.AWSResourceName(roleARN), nil


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2031

Description of changes:

Add support of `team-id` annotation in the namespace. Each `team-id` can associate with a different AWS Role ARN. So that the controller can have different roles for different namespaces. It can help fine grained permission when different teams and users are using the same controller. 

Changes:
- On top of https://github.com/aws-controllers-k8s/runtime/pull/143
- Add a `team-id` annotation
- If both `team-id` and `owner-account-id` exist. It will take the `team-id` and ignore `owner-account-id`.

Sample usage:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: ack-carm-map
  namespace: ack-system
data:
  owner-account-id/111111111111: arn:aws:iam::111111111111:role/s3FullAccess
  team-id/team-a:  'arn:aws:arn:aws:iam::123456789012:role/read-only'
---
apiVersion: v1
kind: Namespace
metadata:
  name: team
  annotations:
    services.k8s.aws/team-id: "team-a"
---
apiVersion: v1
kind: Namespace
metadata:
  name: account
  annotations:
    services.k8s.aws/owner-account-id: "111111111111"
---
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
