### PR TITLE
Create a seperated CARM map from accounts

### DIFF
--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -122,7 +122,7 @@ func (r *adoptionReconciler) reconcile(ctx context.Context, req ctrlrt.Request) 
 		// annotated with an owner account ID. We need to retrieve the
 		// roleARN from the ConfigMap and properly requeue if the roleARN
 		// is not available.
-		roleARN, err = r.getRoleARN(acctID)
+		roleARN, err = r.getOwnerAccountRoleARN(acctID)
 		if err != nil {
 			ackrtlog.InfoAdoptedResource(r.log, res, fmt.Sprintf("Unable to start adoption reconcilliation %s: %v", acctID, err))
 			// r.getRoleARN errors are not terminal, we should requeue.
@@ -478,14 +478,20 @@ func (r *adoptionReconciler) getEndpointURL(
 	return r.cfg.EndpointURL
 }
 
-// getRoleARN return the Role ARN that should be assumed in order to manage
+// getOwnerAccountRoleARN return the Role ARN that should be assumed in order to manage
 // the resources.
-func (r *adoptionReconciler) getRoleARN(
+func (r *adoptionReconciler) getOwnerAccountRoleARN(
 	acctID ackv1alpha1.AWSAccountID,
 ) (ackv1alpha1.AWSResourceName, error) {
-	roleARN, err := r.cache.Accounts.GetAccountRoleARN(string(acctID))
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+	roleARN, err := r.cache.CARMMaps.GetValue(ackrtcache.OwnerAccountIDPrefix + string(acctID))
+	if err == ackrtcache.ErrCARMConfigMapNotFound || err == ackrtcache.ErrKeyNotFound {
+		// CARM map v2 not defined. Check v1 map.
+		roleARN, err = r.cache.Accounts.GetValue(string(acctID))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("unable to retrieve role ARN from CARM v2 for account %s: %v", acctID, err)
 	}
 	return ackv1alpha1.AWSResourceName(roleARN), nil
 }

--- a/pkg/runtime/cache/account.go
+++ b/pkg/runtime/cache/account.go
@@ -28,48 +28,53 @@ var (
 	// ErrCARMConfigMapNotFound is an error that is returned when the CARM
 	// configmap is not found.
 	ErrCARMConfigMapNotFound = errors.New("CARM configmap not found")
-	// ErrAccountIDNotFound is an error that is returned when the account ID
+	// ErrKeyNotFound is an error that is returned when the account ID
 	// is not found in the CARM configmap.
-	ErrAccountIDNotFound = errors.New("account ID not found in CARM configmap")
-	// ErrEmptyRoleARN is an error that is returned when the role ARN is empty
+	ErrKeyNotFound = errors.New("key not found in CARM configmap")
+	// ErrEmptyValue is an error that is returned when the role ARN is empty
 	// in the CARM configmap.
-	ErrEmptyRoleARN = errors.New("role ARN is empty in CARM configmap")
+	ErrEmptyValue = errors.New("role value is empty in CARM configmap")
 )
 
 const (
 	// ACKRoleAccountMap is the name of the configmap map object storing
 	// all the AWS Account IDs associated with their AWS Role ARNs.
 	ACKRoleAccountMap = "ack-role-account-map"
+
+	// ACKCARMMapV2 is the name of the v2 CARM map.
+	// It stores the mapping for:
+	// - Account ID to the AWS role ARNs.
+	ACKCARMMapV2 = "ack-carm-map"
 )
 
-// AccountCache is responsible for caching the CARM configmap
+// CARMMap is responsible for caching the CARM configmap
 // data. It is listening to all the events related to the CARM map and
 // make the changes accordingly.
-type AccountCache struct {
+type CARMMap struct {
 	sync.RWMutex
 	log              logr.Logger
-	roleARNs         map[string]string
+	data             map[string]string
 	configMapCreated bool
 }
 
-// NewAccountCache instanciate a new AccountCache.
-func NewAccountCache(log logr.Logger) *AccountCache {
-	return &AccountCache{
+// NewCARMMapCache instanciate a new CARMMap.
+func NewCARMMapCache(log logr.Logger) *CARMMap {
+	return &CARMMap{
 		log:              log.WithName("cache.account"),
-		roleARNs:         make(map[string]string),
+		data:             make(map[string]string),
 		configMapCreated: false,
 	}
 }
 
-// resourceMatchACKRoleAccountConfigMap verifies if a resource is
+// resourceMatchCARMConfigMap verifies if a resource is
 // the CARM configmap. It verifies the name, namespace and object type.
-func resourceMatchACKRoleAccountsConfigMap(raw interface{}) bool {
+func resourceMatchCARMConfigMap(raw interface{}, name string) bool {
 	object, ok := raw.(*corev1.ConfigMap)
-	return ok && object.ObjectMeta.Name == ACKRoleAccountMap
+	return ok && object.ObjectMeta.Name == name
 }
 
 // Run instantiate a new SharedInformer for ConfigMaps and runs it to begin processing items.
-func (c *AccountCache) Run(clientSet kubernetes.Interface, stopCh <-chan struct{}) {
+func (c *CARMMap) Run(name string, clientSet kubernetes.Interface, stopCh <-chan struct{}) {
 	c.log.V(1).Info("Starting shared informer for accounts cache", "targetConfigMap", ACKRoleAccountMap)
 	informer := informersv1.NewConfigMapInformer(
 		clientSet,
@@ -79,33 +84,33 @@ func (c *AccountCache) Run(clientSet kubernetes.Interface, stopCh <-chan struct{
 	)
 	informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			if resourceMatchACKRoleAccountsConfigMap(obj) {
+			if resourceMatchCARMConfigMap(obj, name) {
 				cm := obj.(*corev1.ConfigMap)
 				object := cm.DeepCopy()
 				// To avoid multiple mutex locks, we are updating the cache
 				// and the configmap existence flag in the same function.
 				configMapCreated := true
-				c.updateAccountRoleData(configMapCreated, object.Data)
+				c.updateData(configMapCreated, object.Data)
 				c.log.V(1).Info("created account config map", "name", cm.ObjectMeta.Name)
 			}
 		},
 		UpdateFunc: func(orig, desired interface{}) {
-			if resourceMatchACKRoleAccountsConfigMap(desired) {
+			if resourceMatchCARMConfigMap(desired, name) {
 				cm := desired.(*corev1.ConfigMap)
 				object := cm.DeepCopy()
 				//TODO(a-hilaly): compare data checksum before updating the cache
-				c.updateAccountRoleData(true, object.Data)
+				c.updateData(true, object.Data)
 				c.log.V(1).Info("updated account config map", "name", cm.ObjectMeta.Name)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			if resourceMatchACKRoleAccountsConfigMap(obj) {
+			if resourceMatchCARMConfigMap(obj, name) {
 				cm := obj.(*corev1.ConfigMap)
 				newMap := make(map[string]string)
 				// To avoid multiple mutex locks, we are updating the cache
 				// and the configmap existence flag in the same function.
 				configMapCreated := false
-				c.updateAccountRoleData(configMapCreated, newMap)
+				c.updateData(configMapCreated, newMap)
 				c.log.V(1).Info("deleted account config map", "name", cm.ObjectMeta.Name)
 			}
 		},
@@ -113,33 +118,33 @@ func (c *AccountCache) Run(clientSet kubernetes.Interface, stopCh <-chan struct{
 	go informer.Run(stopCh)
 }
 
-// GetAccountRoleARN queries the AWS accountID associated Role ARN
+// GetValue queries the value
 // from the cached CARM configmap. It will return an error if the
-// configmap is not found, the accountID is not found or the role ARN
+// configmap is not found, the key is not found or the value
 // is empty.
 //
 // This function is thread safe.
-func (c *AccountCache) GetAccountRoleARN(accountID string) (string, error) {
+func (c *CARMMap) GetValue(key string) (string, error) {
 	c.RLock()
 	defer c.RUnlock()
 
 	if !c.configMapCreated {
 		return "", ErrCARMConfigMapNotFound
 	}
-	roleARN, ok := c.roleARNs[accountID]
+	roleARN, ok := c.data[key]
 	if !ok {
-		return "", ErrAccountIDNotFound
+		return "", ErrKeyNotFound
 	}
 	if roleARN == "" {
-		return "", ErrEmptyRoleARN
+		return "", ErrEmptyValue
 	}
 	return roleARN, nil
 }
 
-// updateAccountRoleData updates the CARM map. This function is thread safe.
-func (c *AccountCache) updateAccountRoleData(exist bool, data map[string]string) {
+// updateData updates the CARM map. This function is thread safe.
+func (c *CARMMap) updateData(exist bool, data map[string]string) {
 	c.Lock()
 	defer c.Unlock()
-	c.roleARNs = data
+	c.data = data
 	c.configMapCreated = exist
 }

--- a/pkg/runtime/cache/account_test.go
+++ b/pkg/runtime/cache/account_test.go
@@ -64,13 +64,13 @@ func TestAccountCache(t *testing.T) {
 	fakeLogger := ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&zapOptions))
 
 	// initlizing account cache
-	accountCache := ackrtcache.NewAccountCache(fakeLogger)
+	accountCache := ackrtcache.NewCARMMapCache(fakeLogger)
 	stopCh := make(chan struct{})
-	accountCache.Run(k8sClient, stopCh)
+	accountCache.Run(ackrtcache.ACKRoleAccountMap, k8sClient, stopCh)
 
 	// Before creating the configmap, the accountCache should error for any
 	// GetAccountRoleARN call.
-	_, err := accountCache.GetAccountRoleARN(testAccount1)
+	_, err := accountCache.GetValue(testAccount1)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
@@ -90,12 +90,12 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test with non existing account
-	_, err = accountCache.GetAccountRoleARN("random-account-not-exist")
+	_, err = accountCache.GetValue("random-account-not-exist")
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
 	// Test with existing account
-	_, err = accountCache.GetAccountRoleARN(testAccount1)
+	_, err = accountCache.GetValue(testAccount1)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
@@ -114,17 +114,17 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test with non existing account
-	_, err = accountCache.GetAccountRoleARN("random-account-not-exist")
+	_, err = accountCache.GetValue("random-account-not-exist")
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrAccountIDNotFound)
+	require.Equal(t, err, ackrtcache.ErrKeyNotFound)
 
 	// Test with existing account - but role ARN is empty
-	_, err = accountCache.GetAccountRoleARN(testAccount3)
+	_, err = accountCache.GetValue(testAccount3)
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrEmptyRoleARN)
+	require.Equal(t, err, ackrtcache.ErrEmptyValue)
 
 	// Test with existing account
-	roleARN, err := accountCache.GetAccountRoleARN(testAccount1)
+	roleARN, err := accountCache.GetValue(testAccount1)
 	require.Nil(t, err)
 	require.Equal(t, roleARN, testAccountARN1)
 
@@ -144,21 +144,21 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test with non existing account
-	_, err = accountCache.GetAccountRoleARN("random-account-not-exist")
+	_, err = accountCache.GetValue("random-account-not-exist")
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrAccountIDNotFound)
+	require.Equal(t, err, ackrtcache.ErrKeyNotFound)
 
 	// Test that account was removed
-	_, err = accountCache.GetAccountRoleARN(testAccount3)
+	_, err = accountCache.GetValue(testAccount3)
 	require.NotNil(t, err)
-	require.Equal(t, err, ackrtcache.ErrAccountIDNotFound)
+	require.Equal(t, err, ackrtcache.ErrKeyNotFound)
 
 	// Test with existing account
-	roleARN, err = accountCache.GetAccountRoleARN(testAccount1)
+	roleARN, err = accountCache.GetValue(testAccount1)
 	require.Nil(t, err)
 	require.Equal(t, roleARN, testAccountARN1)
 
-	roleARN, err = accountCache.GetAccountRoleARN(testAccount2)
+	roleARN, err = accountCache.GetValue(testAccount2)
 	require.Nil(t, err)
 	require.Equal(t, roleARN, testAccountARN2)
 
@@ -172,15 +172,15 @@ func TestAccountCache(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Test that accounts ware removed
-	_, err = accountCache.GetAccountRoleARN(testAccount1)
+	_, err = accountCache.GetValue(testAccount1)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
-	_, err = accountCache.GetAccountRoleARN(testAccount2)
+	_, err = accountCache.GetValue(testAccount2)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 
-	_, err = accountCache.GetAccountRoleARN(testAccount3)
+	_, err = accountCache.GetValue(testAccount3)
 	require.NotNil(t, err)
 	require.Equal(t, err, ackrtcache.ErrCARMConfigMapNotFound)
 }

--- a/pkg/runtime/cache/cache.go
+++ b/pkg/runtime/cache/cache.go
@@ -43,6 +43,9 @@ const (
 	// caching system not to set up resyncs with an authoritative state source
 	// (i.e. a Kubernetes API server) on a periodic basis.
 	informerResyncPeriod = 0 * time.Second
+
+	// The prefix for owner account ID in the v2 CARM map.
+	OwnerAccountIDPrefix = "owner-account-id/"
 )
 
 // ackSystemNamespace is the namespace in which we look up ACK system
@@ -73,7 +76,10 @@ type Caches struct {
 	stopCh chan struct{}
 
 	// Accounts cache
-	Accounts *AccountCache
+	Accounts *CARMMap
+
+	// CARMMaps v2 cache
+	CARMMaps *CARMMap
 
 	// Namespaces cache
 	Namespaces *NamespaceCache
@@ -82,7 +88,8 @@ type Caches struct {
 // New instantiate a new Caches object.
 func New(log logr.Logger, config Config) Caches {
 	return Caches{
-		Accounts:   NewAccountCache(log),
+		Accounts:   NewCARMMapCache(log),
+		CARMMaps:   NewCARMMapCache(log),
 		Namespaces: NewNamespaceCache(log, config.WatchScope, config.Ignored),
 	}
 }
@@ -91,7 +98,10 @@ func New(log logr.Logger, config Config) Caches {
 func (c Caches) Run(clientSet kubernetes.Interface) {
 	stopCh := make(chan struct{})
 	if c.Accounts != nil {
-		c.Accounts.Run(clientSet, stopCh)
+		c.Accounts.Run(ACKRoleAccountMap, clientSet, stopCh)
+	}
+	if c.CARMMaps != nil {
+		c.CARMMaps.Run(ACKCARMMapV2, clientSet, stopCh)
 	}
 	if c.Namespaces != nil {
 		c.Namespaces.Run(clientSet, stopCh)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -190,7 +190,7 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 		// annotated with an owner account ID. We need to retrieve the
 		// roleARN from the ConfigMap and properly requeue if the roleARN
 		// is not available.
-		roleARN, err = r.getRoleARN(acctID)
+		roleARN, err = r.getOwnerAccountRoleARN(acctID)
 		if err != nil {
 			// TODO(a-hilaly): Refactor all the reconcile function to make it
 			// easier to understand and maintain.
@@ -1040,15 +1040,22 @@ func (r *resourceReconciler) getOwnerAccountID(
 	return controllerAccountID, false
 }
 
-// getRoleARN return the Role ARN that should be assumed in order to manage
+// getOwnerAccountRoleARN return the Role ARN that should be assumed in order to manage
 // the resources.
-func (r *resourceReconciler) getRoleARN(
+func (r *resourceReconciler) getOwnerAccountRoleARN(
 	acctID ackv1alpha1.AWSAccountID,
 ) (ackv1alpha1.AWSResourceName, error) {
-	roleARN, err := r.cache.Accounts.GetAccountRoleARN(string(acctID))
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+	roleARN, err := r.cache.CARMMaps.GetValue(ackrtcache.OwnerAccountIDPrefix + string(acctID))
+	if err == ackrtcache.ErrCARMConfigMapNotFound || err == ackrtcache.ErrKeyNotFound {
+		// CARM map v2 not defined. Check v1 map.
+		roleARN, err = r.cache.Accounts.GetValue(string(acctID))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve role ARN for account %s: %v", acctID, err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("unable to retrieve role ARN from CARM v2 for account %s: %v", acctID, err)
 	}
+
 	return ackv1alpha1.AWSResourceName(roleARN), nil
 }
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2031

Description of changes:

Add a new version the CARM map in parallel of existing `ack-role-account-map` 

Usage:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: ack-carm-map
  namespace: $ACK_SYSTEM_NAMESPACE
data:
  owner-account-id/111111111111: arn:aws:iam::111111111111:role/s3FullAccess
```

If the account ID in `ack-carm-map` exists, we will use this value. Otherwise, it will use the value in the older version  `ack-role-account-map` .

This will allow the expension to the key of `team-id/team-a`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
