### PR TITLE
Add a new flag for enabling/disabling AdoptedResource reconciler

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ import (
 )
 
 const (
+	flagEnableAdoptedResourceReconciler = "enable-adopted-resource-reconciler"
 	flagEnableLeaderElection            = "enable-leader-election"
 	flagLeaderElectionNamespace         = "leader-election-namespace"
 	flagMetricAddr                      = "metrics-addr"
@@ -79,6 +80,7 @@ type Config struct {
 	MetricsAddr                     string
 	HealthzAddr                     string
 	EnableLeaderElection            bool
+	EnableAdoptedResourceReconciler bool
 	LeaderElectionNamespace         string
 	EnableDevelopmentLogging        bool
 	AccountID                       string
@@ -125,6 +127,11 @@ func (cfg *Config) BindFlags() {
 		false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.",
+	)
+	flag.BoolVar(
+		&cfg.EnableAdoptedResourceReconciler, flagEnableAdoptedResourceReconciler,
+		true,
+		"Enable the AdoptedResource reconciler.",
 	)
 	flag.StringVar(
 		// In the context of the controller-runtime library, if the LeaderElectionNamespace parametere is not

--- a/pkg/runtime/service_controller.go
+++ b/pkg/runtime/service_controller.go
@@ -235,18 +235,20 @@ func (c *serviceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg
 		cache.Run(clientSet)
 	}
 
-	adoptionInstalled, err := c.GetAdoptedResourceInstalled(mgr)
-	adoptionLogger := c.log.WithName("adoption")
-	if err != nil {
-		adoptionLogger.Error(err, "unable to determine if the AdoptedResource CRD is installed in the cluster")
-	} else if !adoptionInstalled {
-		adoptionLogger.Info("AdoptedResource CRD not installed. The adoption reconciler will not be started")
-	} else {
-		rec := NewAdoptionReconciler(c, adoptionLogger, cfg, c.metrics, cache)
-		if err := rec.BindControllerManager(mgr); err != nil {
-			return err
+	if cfg.EnableAdoptedResourceReconciler {
+		adoptionInstalled, err := c.GetAdoptedResourceInstalled(mgr)
+		adoptionLogger := c.log.WithName("adoption")
+		if err != nil {
+			adoptionLogger.Error(err, "unable to determine if the AdoptedResource CRD is installed in the cluster")
+		} else if !adoptionInstalled {
+			adoptionLogger.Info("AdoptedResource CRD not installed. The adoption reconciler will not be started")
+		} else {
+			rec := NewAdoptionReconciler(c, adoptionLogger, cfg, c.metrics, cache)
+			if err := rec.BindControllerManager(mgr); err != nil {
+				return err
+			}
+			c.adoptionReconciler = rec
 		}
-		c.adoptionReconciler = rec
 	}
 
 	exporterInstalled, err := c.GetFieldExportInstalled(mgr)


### PR DESCRIPTION
This commit adds a new feature flag `enable-adopted-resource-reconciler` to
allow enabling or disabling the `AdoptedResource` reconciler. The reconciler
is now only started if this flag is set to true.

This lays the groundwork for a new way to adopt resources, via an adopted
resource annotation instead of using the `AdoptedResource` custom resource.

This change provides more flexibility in choosing whether users want to
use the AdoptedResource CRD or the adoption annotation to adopt
resources.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
