### PR TITLE
Add cross namespace resource reference support in runtime

### DIFF
--- a/apis/core/v1alpha1/identifiers.go
+++ b/apis/core/v1alpha1/identifiers.go
@@ -72,5 +72,6 @@ type AWSResourceReferenceWrapper struct {
 // AWSResourceReference provides all the values necessary to reference another
 // k8s resource for finding the identifier(Id/ARN/Name)
 type AWSResourceReference struct {
-	Name *string `json:"name,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	Namespace *string `json:"namespace,omitempty"`
 }


### PR DESCRIPTION
Issue [#1777](https://github.com/aws-controllers-k8s/community/issues/1777)

Description of changes:
* Added namespace string to AWSResourceReference struct
* Needs testing
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
