### PR TITLE
Update `AWSResourceManagerFactory` to include `roleARN` paramter

### DIFF
--- a/mocks/pkg/types/aws_resource_manager_factory.go
+++ b/mocks/pkg/types/aws_resource_manager_factory.go
@@ -36,25 +36,25 @@ func (_m *AWSResourceManagerFactory) IsAdoptable() bool {
 	return r0
 }
 
-// ManagerFor provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5, _a6
-func (_m *AWSResourceManagerFactory) ManagerFor(_a0 config.Config, _a1 logr.Logger, _a2 *metrics.Metrics, _a3 types.Reconciler, _a4 *session.Session, _a5 v1alpha1.AWSAccountID, _a6 v1alpha1.AWSRegion) (types.AWSResourceManager, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
+// ManagerFor provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7
+func (_m *AWSResourceManagerFactory) ManagerFor(_a0 config.Config, _a1 logr.Logger, _a2 *metrics.Metrics, _a3 types.Reconciler, _a4 *session.Session, _a5 v1alpha1.AWSAccountID, _a6 v1alpha1.AWSRegion, _a7 v1alpha1.AWSResourceName) (types.AWSResourceManager, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
 
 	var r0 types.AWSResourceManager
 	var r1 error
-	if rf, ok := ret.Get(0).(func(config.Config, logr.Logger, *metrics.Metrics, types.Reconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) (types.AWSResourceManager, error)); ok {
-		return rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
+	if rf, ok := ret.Get(0).(func(config.Config, logr.Logger, *metrics.Metrics, types.Reconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion, v1alpha1.AWSResourceName) (types.AWSResourceManager, error)); ok {
+		return rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
 	}
-	if rf, ok := ret.Get(0).(func(config.Config, logr.Logger, *metrics.Metrics, types.Reconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) types.AWSResourceManager); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
+	if rf, ok := ret.Get(0).(func(config.Config, logr.Logger, *metrics.Metrics, types.Reconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion, v1alpha1.AWSResourceName) types.AWSResourceManager); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.AWSResourceManager)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(config.Config, logr.Logger, *metrics.Metrics, types.Reconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) error); ok {
-		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
+	if rf, ok := ret.Get(1).(func(config.Config, logr.Logger, *metrics.Metrics, types.Reconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion, v1alpha1.AWSResourceName) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -142,7 +142,7 @@ func (r *adoptionReconciler) reconcile(ctx context.Context, req ctrlrt.Request) 
 	ackrtlog.InfoAdoptedResource(r.log, res, "starting adoption reconciliation")
 
 	rm, err := rmf.ManagerFor(
-		r.cfg, r.log, r.metrics, r, sess, acctID, region,
+		r.cfg, r.log, r.metrics, r, sess, acctID, region, roleARN,
 	)
 	if err != nil {
 		return err

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -266,7 +266,7 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 	)
 
 	rm, err := r.rmf.ManagerFor(
-		r.cfg, r.log, r.metrics, r, sess, acctID, region,
+		r.cfg, r.log, r.metrics, r, sess, acctID, region, roleARN,
 	)
 	if err != nil {
 		return ctrlrt.Result{}, err

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -106,6 +106,7 @@ type AWSResourceManagerFactory interface {
 		*session.Session,
 		ackv1alpha1.AWSAccountID,
 		ackv1alpha1.AWSRegion,
+		ackv1alpha1.AWSResourceName,
 	) (AWSResourceManager, error)
 	// IsAdoptable returns true if the resource is able to be adopted
 	IsAdoptable() bool


### PR DESCRIPTION
This patch modifies the `AWSResourceManageFactory` intgerface and
its implementation to include a `roleARN` parameter in the
`ManagerFor` function.

The addition of `roleARN` is necessary to support fine-grained
access control and multi-tenant scenarios where different IAM roles
may be used within the same AWS account and region. This change
corresponds to the updates in code-generaotr repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
