### PR TITLE
Handling controller error when there is no default account ID

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,7 +85,7 @@ type Config struct {
 	EnableAdoptedResourceReconciler bool
 	LeaderElectionNamespace         string
 	EnableDevelopmentLogging        bool
-	AccountID                       string
+	DefaultAccountID                string
 	Region                          string
 	IdentityEndpointURL             string
 	EndpointURL                     string
@@ -271,9 +271,15 @@ func (cfg *Config) SetAWSAccountID() error {
 	client := sts.New(session)
 	res, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
-		return fmt.Errorf("unable to get caller identity: %v", err)
+		// When a default account ID is not provided,
+		// we will be checking namespaces and carm
+		// for accountIDs in main reconciliation loop
+		klog.Info("Default account ID not found")
+		cfg.DefaultAccountID = ""
+	} else {
+		cfg.DefaultAccountID = *res.Account
 	}
-	cfg.AccountID = *res.Account
+	
 	return nil
 }
 

--- a/pkg/runtime/adoption_reconciler.go
+++ b/pkg/runtime/adoption_reconciler.go
@@ -472,7 +472,7 @@ func (r *adoptionReconciler) getOwnerAccountID(
 	}
 
 	// use controller configuration
-	return ackv1alpha1.AWSAccountID(r.cfg.AccountID), false
+	return ackv1alpha1.AWSAccountID(r.cfg.DefaultAccountID), false
 }
 
 // getTeamID returns the team ID that owns the supplied resource.

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -257,6 +257,8 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 		if err != nil {
 			return r.handleCacheError(ctx, err, desired)
 		}
+	} else if !needCARMLookup && acctID == "" {
+		return ctrlrt.Result{}, fmt.Errorf("unable to locate AWS credentials to manage resource: both controller credentials and a proper CARM configuration are missing")
 	}
 
 	region := r.getRegion(desired)
@@ -1100,7 +1102,7 @@ func (r *resourceReconciler) getOwnerAccountID(
 		return ackv1alpha1.AWSAccountID(accID), true
 	}
 
-	controllerAccountID := ackv1alpha1.AWSAccountID(r.cfg.AccountID)
+	controllerAccountID := ackv1alpha1.AWSAccountID(r.cfg.DefaultAccountID)
 	// look for owner account id in the resource status
 	acctID := res.Identifiers().OwnerAccountID()
 	if acctID != nil {


### PR DESCRIPTION
Issue [#2111](https://github.com/aws-controllers-k8s/community/issues/2111)

Description of changes:

Previously the controller was exiting with an error 
when there was no credentials provided by user, through
environment variables or the config files.

By not exiting the controller immediately, we allow the 
user to provide account IDs through the CARM features.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
