### PR TITLE
Add addoption by annotation feature

### DIFF
--- a/apis/core/v1alpha1/annotations.go
+++ b/apis/core/v1alpha1/annotations.go
@@ -81,11 +81,12 @@ const (
 	// the resource is read-only and should not be created/patched/deleted by the
 	// ACK service controller.
 	AnnotationReadOnly = AnnotationPrefix + "read-only"
-	// AnnotationForceAdoption is an annotation whose value is the identifier for whether
-	// we will force adoption or not. If this annotation is set to true on a CR, that
-	// means the user is indicating to the ACK service controller that it should
-	// force adoption of the resource.
-	AnnotationForceAdoption = AnnotationPrefix + "force-adoption"
+	// AnnotationAdoptionPolicy is an annotation whose value is the identifier for whether
+	// we will attempt adoption only (value = adopt-only) or attempt a create if resource 
+	// is not found (value adopt-or-create).
+	//
+	// NOTE (michaelhtm): Currently create-or-adopt is not supported
+	AnnotationAdoptionPolicy = AnnotationPrefix + "adoption-policy"
 	// AnnotationAdoptionFields is an annotation whose value contains a json-like
 	// format of the requied fields to do a ReadOne when attempting to force-adopt
 	// a Resource

--- a/apis/core/v1alpha1/annotations.go
+++ b/apis/core/v1alpha1/annotations.go
@@ -81,4 +81,13 @@ const (
 	// the resource is read-only and should not be created/patched/deleted by the
 	// ACK service controller.
 	AnnotationReadOnly = AnnotationPrefix + "read-only"
+	// AnnotationForceAdoption is an annotation whose value is the identifier for whether
+	// we will force adoption or not. If this annotation is set to true on a CR, that
+	// means the user is indicating to the ACK service controller that it should
+	// force adoption of the resource.
+	AnnotationForceAdoption = AnnotationPrefix + "force-adoption"
+	// AnnotationAdoptionFields is an annotation whose value contains a json-like
+	// format of the requied fields to do a ReadOne when attempting to force-adopt
+	// a Resource
+	AnnotationAdoptionFields = AnnotationPrefix + "adoption-fields"
 )

--- a/mocks/pkg/types/aws_resource.go
+++ b/mocks/pkg/types/aws_resource.go
@@ -131,6 +131,20 @@ func (_m *AWSResource) SetIdentifiers(_a0 *v1alpha1.AWSIdentifiers) error {
 	return r0
 }
 
+// PopulateResourceFromAnnotation provides a mock function with given fields: _a0
+func (_m *AWSResource) PopulateResourceFromAnnotation(_a0 map[string]string) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(map[string]string) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetObjectMeta provides a mock function with given fields: meta
 func (_m *AWSResource) SetObjectMeta(meta v1.ObjectMeta) {
 	_m.Called(meta)

--- a/pkg/featuregate/features.go
+++ b/pkg/featuregate/features.go
@@ -19,9 +19,9 @@ package featuregate
 import "fmt"
 
 const (
-	// AdoptResources is a feature gate for enabling forced adoption of resources
+	// ResourceAdoption is a feature gate for enabling forced adoption of resources
 	// by annotation
-	AdoptResources = "AdoptResources"
+	ResourceAdoption = "ResourceAdoption"
 
 	// ReadOnlyResources is a feature gate for enabling ReadOnly resources annotation.
 	ReadOnlyResources = "ReadOnlyResources"
@@ -36,7 +36,7 @@ const (
 // defaultACKFeatureGates is a map of feature names to Feature structs
 // representing the default feature gates for ACK controllers.
 var defaultACKFeatureGates = FeatureGates{
-	AdoptResources:    {Stage: Alpha, Enabled: false},
+	ResourceAdoption:  {Stage: Alpha, Enabled: false},
 	ReadOnlyResources: {Stage: Alpha, Enabled: false},
 	TeamLevelCARM:     {Stage: Alpha, Enabled: false},
 	ServiceLevelCARM:  {Stage: Alpha, Enabled: false},

--- a/pkg/featuregate/features.go
+++ b/pkg/featuregate/features.go
@@ -19,9 +19,9 @@ package featuregate
 import "fmt"
 
 const (
-	// ForcedAdoptResources is a feature gate for enabling forced adoption of resources
+	// AdoptResources is a feature gate for enabling forced adoption of resources
 	// by annotation
-	ForcedAdoptResources = "ForcedAdoptResources"
+	AdoptResources = "AdoptResources"
 
 	// ReadOnlyResources is a feature gate for enabling ReadOnly resources annotation.
 	ReadOnlyResources = "ReadOnlyResources"
@@ -36,10 +36,10 @@ const (
 // defaultACKFeatureGates is a map of feature names to Feature structs
 // representing the default feature gates for ACK controllers.
 var defaultACKFeatureGates = FeatureGates{
-	ForcedAdoptResources: {Stage: Alpha, Enabled: false},
-	ReadOnlyResources:    {Stage: Alpha, Enabled: false},
-	TeamLevelCARM:        {Stage: Alpha, Enabled: false},
-	ServiceLevelCARM:     {Stage: Alpha, Enabled: false},
+	AdoptResources:    {Stage: Alpha, Enabled: false},
+	ReadOnlyResources: {Stage: Alpha, Enabled: false},
+	TeamLevelCARM:     {Stage: Alpha, Enabled: false},
+	ServiceLevelCARM:  {Stage: Alpha, Enabled: false},
 }
 
 // FeatureStage represents the development stage of a feature.

--- a/pkg/featuregate/features.go
+++ b/pkg/featuregate/features.go
@@ -19,6 +19,10 @@ package featuregate
 import "fmt"
 
 const (
+	// ForcedAdoptResources is a feature gate for enabling forced adoption of resources
+	// by annotation
+	ForcedAdoptResources = "ForcedAdoptResources"
+
 	// ReadOnlyResources is a feature gate for enabling ReadOnly resources annotation.
 	ReadOnlyResources = "ReadOnlyResources"
 
@@ -32,9 +36,10 @@ const (
 // defaultACKFeatureGates is a map of feature names to Feature structs
 // representing the default feature gates for ACK controllers.
 var defaultACKFeatureGates = FeatureGates{
-	ReadOnlyResources: {Stage: Alpha, Enabled: false},
-	TeamLevelCARM:     {Stage: Alpha, Enabled: false},
-	ServiceLevelCARM:  {Stage: Alpha, Enabled: false},
+	ForcedAdoptResources: {Stage: Alpha, Enabled: false},
+	ReadOnlyResources:    {Stage: Alpha, Enabled: false},
+	TeamLevelCARM:        {Stage: Alpha, Enabled: false},
+	ServiceLevelCARM:     {Stage: Alpha, Enabled: false},
 }
 
 // FeatureStage represents the development stage of a feature.

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -70,30 +70,29 @@ func IsReadOnly(res acktypes.AWSResource) bool {
 	return false
 }
 
-// hasAdoptAnnotation returns true if the supplied AWSResource has an annotation
-// indicating that it should be adopted
-func hasAdoptAnnotation(res acktypes.AWSResource) bool {
+// GetAdoptionPolicy returns the Adoption Policy of the resource
+// defined by the user in annotation. Possible values are: 
+// adopt-only | adopt-or-create
+// adopt-only keeps requing until the resource is found
+// adopt-or-create creates the resource if does not exist
+func GetAdoptionPolicy(res acktypes.AWSResource) string {
 	mo := res.MetaObject()
 	if mo == nil {
-		// Should never happen... if it does, it's buggy code.
-		panic("hasAdoptAnnotation received resource with nil RuntimeObject")
+		panic("getAdoptionPolicy received resource with nil RuntimeObject")
 	}
 	for k, v := range mo.GetAnnotations() {
-		if k == ackv1alpha1.AnnotationForceAdoption {
-			return strings.ToLower(v) == "true"
+		if k == ackv1alpha1.AnnotationAdoptionPolicy {
+			return v
 		}
 	}
-	return false
+
+	return ""
 }
 
-func createOrAdopt(res acktypes.AWSResource) bool {
-	return hasAdoptAnnotation(res) || IsAdopted(res)
-}
-
-// NeedAdoption returns true when the resource has 
+// NeedAdoption returns true when the resource has
 // adopt annotation but is not yet adopted
 func NeedAdoption(res acktypes.AWSResource) bool {
-	return hasAdoptAnnotation(res) && !IsAdopted(res)
+	return GetAdoptionPolicy(res) != "" && !IsAdopted(res) 
 }
 
 func ExtractAdoptionFields(res acktypes.AWSResource) (map[string]string, error) {

--- a/pkg/runtime/util_test.go
+++ b/pkg/runtime/util_test.go
@@ -74,8 +74,8 @@ func TestIsForcedAdoption(t *testing.T) {
 	res := &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
 		Annotations: map[string]string{
-			ackv1alpha1.AnnotationForceAdoption: "true",
-			ackv1alpha1.AnnotationAdopted: "false",
+			ackv1alpha1.AnnotationAdoptionPolicy: "true",
+			ackv1alpha1.AnnotationAdopted:        "false",
 		},
 	})
 	require.True(ackrt.NeedAdoption(res))
@@ -83,8 +83,8 @@ func TestIsForcedAdoption(t *testing.T) {
 	res = &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
 		Annotations: map[string]string{
-			ackv1alpha1.AnnotationForceAdoption: "true",
-			ackv1alpha1.AnnotationAdopted: "true",
+			ackv1alpha1.AnnotationAdoptionPolicy: "true",
+			ackv1alpha1.AnnotationAdopted:        "true",
 		},
 	})
 	require.False(ackrt.NeedAdoption(res))
@@ -92,8 +92,8 @@ func TestIsForcedAdoption(t *testing.T) {
 	res = &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
 		Annotations: map[string]string{
-			ackv1alpha1.AnnotationForceAdoption: "false",
-			ackv1alpha1.AnnotationAdopted: "true",
+			ackv1alpha1.AnnotationAdoptionPolicy: "false",
+			ackv1alpha1.AnnotationAdopted:        "true",
 		},
 	})
 	require.False(ackrt.NeedAdoption(res))
@@ -111,10 +111,10 @@ func TestExtractAdoptionFields(t *testing.T) {
 			}`,
 		},
 	})
-	
+
 	expected := map[string]string{
 		"clusterName": "my-cluster",
-		"name": "ng-1234",
+		"name":        "ng-1234",
 	}
 	actual, err := ackrt.ExtractAdoptionFields(res)
 	require.NoError(err)

--- a/pkg/runtime/util_test.go
+++ b/pkg/runtime/util_test.go
@@ -67,3 +67,56 @@ func TestIsSynced(t *testing.T) {
 	})
 	require.False(ackrt.IsSynced(res))
 }
+
+func TestIsForcedAdoption(t *testing.T) {
+	require := require.New(t)
+
+	res := &mocks.AWSResource{}
+	res.On("MetaObject").Return(&metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationForceAdoption: "true",
+			ackv1alpha1.AnnotationAdopted: "false",
+		},
+	})
+	require.True(ackrt.NeedAdoption(res))
+
+	res = &mocks.AWSResource{}
+	res.On("MetaObject").Return(&metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationForceAdoption: "true",
+			ackv1alpha1.AnnotationAdopted: "true",
+		},
+	})
+	require.False(ackrt.NeedAdoption(res))
+
+	res = &mocks.AWSResource{}
+	res.On("MetaObject").Return(&metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationForceAdoption: "false",
+			ackv1alpha1.AnnotationAdopted: "true",
+		},
+	})
+	require.False(ackrt.NeedAdoption(res))
+}
+
+func TestExtractAdoptionFields(t *testing.T) {
+	require := require.New(t)
+
+	res := &mocks.AWSResource{}
+	res.On("MetaObject").Return(&metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationAdoptionFields: `{
+				"clusterName": "my-cluster",
+				"name": "ng-1234"
+			}`,
+		},
+	})
+	
+	expected := map[string]string{
+		"clusterName": "my-cluster",
+		"name": "ng-1234",
+	}
+	actual, err := ackrt.ExtractAdoptionFields(res)
+	require.NoError(err)
+	require.Equal(expected, actual)
+}

--- a/pkg/types/aws_resource.go
+++ b/pkg/types/aws_resource.go
@@ -48,4 +48,7 @@ type AWSResource interface {
 	SetStatus(AWSResource)
 	// DeepCopy will return a copy of the resource
 	DeepCopy() AWSResource
+	// PopulateResourceFromAnnotation will set the Spec or Status field that user
+	// provided from annotations
+	PopulateResourceFromAnnotation(fields map[string]string) error 
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
These changes introduce a new feature gate called `ResourceAdoption` 
which allows users to provide the `Read` required fields in the annotation and 
an empty spec, and the controller would populate the resource and adopt 
from AWS

Currently we are considering two values for the `adoption-policy` annotation,
one being `adopt`, which will just try to adopt a resource, and if not found,
keep trying until a resource to adopt exists, or `adopt-or-create` which will
be able to create a resource if adoption fails because resource doesn't exist.

Before we support `adopt-or-create` we need a solution in code-gen
where we change how we handle the `PopulateResourceFromAnnotation`
which currently only allows the population of fields that are
required for a readOne operation, and they happen to be all scalar
fields (besides ARN, but we have a way of handling that), but the
required fields for create would need to be sometimes structs,
and this would require users to provide values in form of maps
eg.
Creating an EKS cluster requires a ResourceVPCConfig, which is a
struct that contains subnetIDs etc.
We can have a couple of ways to address this.
1. Accept these values in the spec, and return terminal error when
   we attempt a create and the create required fields are not provided
2. Accept these values in the `adoption-fields` annotation. This would
   need a code-gen change to allow reading from structs and assigning
   fields. but it would also make the annotation easy to make mistakes
   with when using yaml

Here's an example for cluster:
```yaml
apiVersion: eks.services.k8s.aws/v1alpha1
kind: Cluster
metadata:
  name: my-cluster
  annotations:
    services.k8s.aws/adoption-policy: "adopt"
    services.k8s.aws/adoption-fields: | 
        {
          "name": "my-cluster"
        }
```

Here's another one to adopt a nodegroup

```yaml
apiVersion: eks.services.k8s.aws/v1alpha1
kind: NodeGroup
metadata:
  name: my-ng
  annotations:
    services.k8s.aws/adoption-policy: "adopt"
    services.k8s.aws/adoption-fields: | 
        {
          "name": "ng-12324",
          "clusterName": "my-cluster"
        }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
