### PR TITLE
feat(tags): filter AWS tags and ACK tags during reconciliation

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -114,6 +114,11 @@ func (_m *AWSResourceManager) EnsureTags(_a0 context.Context, _a1 types.AWSResou
 	return r0
 }
 
+// FilterSystemTags provides a mock function with given fields: resA
+func (_m *AWSResourceManager) FilterSystemTags(resA types.AWSResource) {
+	_m.Called(resA)
+}
+
 // IsSynced provides a mock function with given fields: _a0, _a1
 func (_m *AWSResourceManager) IsSynced(_a0 context.Context, _a1 types.AWSResource) (bool, error) {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -333,6 +333,7 @@ func (r *resourceReconciler) handleAdoption(
 	rlog.Enter("rm.ReadOne")
 	latest, err := rm.ReadOne(ctx, resolved)
 	rlog.Exit("rm.ReadOne", err)
+	rm.FilterSystemTags(latest)
 	if err != nil {
 		return latest, err
 	}

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -330,14 +330,9 @@ func (r *resourceReconciler) handleAdoption(
 		return nil, err
 	}
 
-	rlog.Enter("rm.EnsureTags")
-	err = rm.EnsureTags(ctx, resolved, r.sc.GetMetadata())
-	rlog.Exit("rm.EnsureTags", err)
-	if err != nil {
-		return resolved, err
-	}
 	rlog.Enter("rm.ReadOne")
 	latest, err := rm.ReadOne(ctx, resolved)
+	rlog.Exit("rm.ReadOne", err)
 	if err != nil {
 		return latest, err
 	}
@@ -346,16 +341,6 @@ func (r *resourceReconciler) handleAdoption(
 		return latest, err
 	}
 
-	// Ensure tags again after adding the finalizer and patching the
-	// resource. Patching desired resource omits the controller tags
-	// because they are not persisted in etcd. So we again ensure
-	// that tags are present before performing the create operation.
-	rlog.Enter("rm.EnsureTags")
-	err = rm.EnsureTags(ctx, latest, r.sc.GetMetadata())
-	rlog.Exit("rm.EnsureTags", err)
-	if err != nil {
-		return latest, err
-	}
 	r.rd.MarkAdopted(latest)
 	rlog.WithValues("is_adopted", "true")
 	latest, err = r.patchResourceMetadataAndSpec(ctx, rm, desired, latest)

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -13,10 +13,6 @@
 
 package tags
 
-import (
-	"strings"
-)
-
 // Tags represents the AWS tags which will be added to the AWS resource.
 // Inside aws-sdk-go, Tags are represented using multiple types, Ex: map of
 // string, list of structs etc...
@@ -50,31 +46,4 @@ func Merge(a Tags, b Tags) Tags {
 		}
 	}
 	return result
-}
-
-// SyncAWSTags ensures AWS-managed tags (prefixed with "aws:") from the latest resource state
-// are preserved in the desired state. This prevents the controller from attempting to
-// modify AWS-managed tags, which would result in an error.
-//
-// AWS-managed tags are automatically added by AWS services (e.g., CloudFormation, Service Catalog)
-// and cannot be modified or deleted through normal tag operations. Common examples include:
-// - aws:cloudformation:stack-name
-// - aws:servicecatalog:productArn
-//
-// Parameters:
-//   - a: The target Tags map to be updated (typically desired state)
-//   - b: The source Tags map containing AWS-managed tags (typically latest state)
-//
-// Example:
-//
-//	latest := Tags{"aws:cloudformation:stack-name": "my-stack", "environment": "prod"}
-//	desired := Tags{"environment": "dev"}
-//	SyncAWSTags(desired, latest)
-//	desired now contains {"aws:cloudformation:stack-name": "my-stack", "environment": "dev"}
-func SyncAWSTags(a Tags, b Tags) {
-	for k := range b {
-		if strings.HasPrefix(k, "aws:") {
-			a[k] = b[k]
-		}
-	}
 }

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -13,6 +13,10 @@
 
 package tags
 
+import (
+	"strings"
+)
+
 // Tags represents the AWS tags which will be added to the AWS resource.
 // Inside aws-sdk-go, Tags are represented using multiple types, Ex: map of
 // string, list of structs etc...
@@ -46,4 +50,31 @@ func Merge(a Tags, b Tags) Tags {
 		}
 	}
 	return result
+}
+
+// SyncAWSTags ensures AWS-managed tags (prefixed with "aws:") from the latest resource state
+// are preserved in the desired state. This prevents the controller from attempting to
+// modify AWS-managed tags, which would result in an error.
+//
+// AWS-managed tags are automatically added by AWS services (e.g., CloudFormation, Service Catalog)
+// and cannot be modified or deleted through normal tag operations. Common examples include:
+// - aws:cloudformation:stack-name
+// - aws:servicecatalog:productArn
+//
+// Parameters:
+//   - a: The target Tags map to be updated (typically desired state)
+//   - b: The source Tags map containing AWS-managed tags (typically latest state)
+//
+// Example:
+//
+//	latest := Tags{"aws:cloudformation:stack-name": "my-stack", "environment": "prod"}
+//	desired := Tags{"environment": "dev"}
+//	SyncAWSTags(desired, latest)
+//	desired now contains {"aws:cloudformation:stack-name": "my-stack", "environment": "dev"}
+func SyncAWSTags(a Tags, b Tags) {
+	for k := range b {
+		if strings.HasPrefix(k, "aws:") {
+			a[k] = b[k]
+		}
+	}
 }

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -85,6 +85,12 @@ type AWSResourceManager interface {
 	// If the AWSResource does not support tags, only then the controller tags
 	// will not be added to the AWSResource.
 	EnsureTags(context.Context, AWSResource, ServiceControllerMetadata) error
+	// FilterSystemTags ignores tags that are either injected by the controller
+	// or by AWS. These tags have keys that start with "aws:" or "services.k8s.aws/"
+	// and this function will remove them before adoption.
+	// Eg. resources created with cloudformation have tags that cannot be
+	//removed by an ACK controller
+	FilterSystemTags(AWSResource)
 }
 
 // AWSResourceManagerFactory returns an AWSResourceManager that can be used to


### PR DESCRIPTION
Description of changes:
When we adopt ACK resources, if those resources are injected by AWS,
we are trying to avoid from patching them into the resource.
For this reason we are adding two new methods for the AWSResourceManager 
interface.

MirrowAWSTags:
This method ensures the AWS tags returned by the API after a read
operation are mirrored in the desired resource. Mirroring the tags in the desired
makes them undetected by the controller.

New FilterSystemTags Function:
Removes System tags injected by AWS (cloudformation aws:) 
or the controller (services.k8s.aws). This method is called during
adoption, to ensure these tags are not patched into the controller.

_____________________________
Also removing EnsureTag operations during adoption to avoid ACK from patching controller tags
to the resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
