### PR TITLE
add `reconcile-reources` flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -398,7 +398,7 @@ func (cfg *Config) validateReconcileConfigResources(supportedGVKs []schema.Group
 	}
 
 	// Also validate the resource filter settings
-	if err := cfg.validateReconcileResources(supportedGVKs); err != nil {
+	if err := cfg.validateReconcileResources(validResourceNames); err != nil {
 		return err
 	}
 
@@ -609,7 +609,7 @@ func parseReconcileResourcesString(resources string) ([]string, error) {
 }
 
 // validateReconcileResources validates that the specified resource kinds are supported by the controller.
-func (cfg *Config) validateReconcileResources(supportedGVKs []schema.GroupVersionKind) error {
+func (cfg *Config) validateReconcileResources(validResourceNames []string) error {
 	resources, err := cfg.GetReconcileResources()
 	if err != nil {
 		return fmt.Errorf("invalid value for flag '%s': %v", flagReconcileResources, err)
@@ -618,18 +618,13 @@ func (cfg *Config) validateReconcileResources(supportedGVKs []schema.GroupVersio
 		return nil
 	}
 
-	validResourceKinds := make([]string, 0, len(supportedGVKs))
-	for _, gvk := range supportedGVKs {
-		validResourceKinds = append(validResourceKinds, gvk.Kind)
-	}
-
 	for _, resource := range resources {
-		if !ackutil.InStrings(resource, validResourceKinds) {
+		if !ackutil.InStrings(resource, validResourceNames) {
 			return fmt.Errorf(
 				"invalid value for flag '%s': resource kind '%s' is not supported by this controller. Valid resource kinds are: %s",
 				flagReconcileResources,
 				resource,
-				strings.Join(validResourceKinds, ", "),
+				strings.Join(validResourceNames, ", "),
 			)
 		}
 	}

--- a/pkg/runtime/service_controller.go
+++ b/pkg/runtime/service_controller.go
@@ -278,10 +278,12 @@ func (c *serviceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg
 		return fmt.Errorf("error parsing reconcile resources: %v", err)
 	}
 
+	if len(reconcileResources) == 0 {
+		c.log.Info("No resources? Did they all go on vacation? Defaulting to reconciling all resources.")
+	}
 	// Filter the resource manager factories
 	filteredRMFs := c.rmFactories
 	if len(reconcileResources) > 0 {
-
 		filteredRMFs = make(map[string]acktypes.AWSResourceManagerFactory)
 		for key, rmf := range c.rmFactories {
 			rd := rmf.ResourceDescriptor()


### PR DESCRIPTION
Description of changes:

The AWS Controllers for Kubernetes (ACK) service controllers currently initialize reconcilers for all supported resource kinds, regardless of operational needs, leading to unnecessary resource consumption and potential for conflicts. We propose introducing a **`--reconcile-resources`** flag that allows operators to specify which resource kinds should be actively reconciled, enabling more efficient resource utilization and operational control. When provided with a comma-separated list of resource kinds (e.g., "Queue,Topic"), the controller will only create reconcilers for those specific resources. This enhancement maintains backward compatibility by continuing to reconcile all resources when the flag is not specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
