### PR TITLE
update: Update the `Resource already exists` condition reason

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -28,7 +28,9 @@ var (
 	NotManagedMessage = "Resource already exists"
 	NotManagedReason  = "This resource already exists but is not managed by ACK. " +
 		"To bring the resource under ACK management, you should explicitly adopt " +
-		"the resource by creating a services.k8s.aws/AdoptedResource"
+		"the resource by enabling the ResourceAdoption feature gate and populating " +
+		"the `services.k8s.aws/adoption-policy` and `services.k8s.aws/adoption-fields` " + 
+		"annotations."
 	UnknownSyncedMessage             = "Unable to determine if desired resource state matches latest observed state"
 	NotSyncedMessage                 = "Resource not synced"
 	SyncedMessage                    = "Resource synced successfully"


### PR DESCRIPTION
Description of changes:
Currently the condition reason for the `Resource Already Exists` 
condition message instructs users to adopt the existing resource 
using the `AdoptResource` CRD, which we no longer implement.

This change updates the message to instruct users to instead use 
the adoption by annotation feature to import an existing resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
