### PR TITLE
feat: Adopt-or-Create

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -311,8 +311,12 @@ func (r *resourceReconciler) handlePopulation(
 	// the required field passed by annotation and attempt a read.
 
 	rlog.Info("Adopting Resource")
+	adoptionPolicy := GetAdoptionPolicy(desired)
 	adoptionFields, err := ExtractAdoptionFields(desired)
 	if err != nil {
+		if adoptionPolicy == "adopt-or-create" {
+			return desired, nil
+		}
 		return desired, ackerr.NewTerminalError(err)
 	}
 
@@ -321,7 +325,7 @@ func (r *resourceReconciler) handlePopulation(
 	// maybe don't return errors when it's adopt-or-create?
 	// TODO (michaelhtm) change PopulateResourceFromAnnotation to understand
 	// adopt-or-create, and validate Spec fields are not nil...
-	if err != nil && GetAdoptionPolicy(desired) != "adopt-or-create" {
+	if err != nil && adoptionPolicy != "adopt-or-create" {
 		return nil, err
 	}
 

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -262,6 +262,205 @@ func TestReconcilerReadOnlyResource(t *testing.T) {
 	rm.AssertNotCalled(t, "Delta", 0)
 }
 
+func TestReconcilerAdoptResource(t *testing.T) {
+	require := require.New(t)
+
+	ctx := context.TODO()
+
+	desired, _, metaObj := resourceMocks()
+	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	metaObj.SetAnnotations(map[string]string{
+		ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
+		ackv1alpha1.AnnotationAdoptionFields: "{\"arn\": \"my-adopt-book-arn\"}",
+	})
+
+	latest, latestRTObj, _ := resourceMocks()
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On("MetaObject").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
+			ackv1alpha1.AnnotationAdoptionFields: "{\"arn\": \"my-adopt-book-arn\"}",
+		},
+	})
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return()
+
+	rm := &ackmocks.AWSResourceManager{}
+	rm.On("ResolveReferences", ctx, nil, desired).Return(
+		desired, false, nil,
+	).Times(2)
+	rm.On("ClearResolvedReferences", desired).Return(desired)
+	rm.On("ClearResolvedReferences", latest).Return(latest)
+	rm.On("ReadOne", ctx, desired).Return(
+		latest, nil,
+	).Once()
+	rm.On("IsSynced", ctx, latest).Return(true, nil)
+	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
+
+	rm.On("LateInitialize", ctx, latest).Return(latest, nil)
+	rd.On("IsManaged", desired).Return(false)
+	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
+	rd.On("Delta", latest, latest).Return(ackcompare.NewDelta())
+
+	r, kc, scmd := reconcilerMocks(rmf)
+	rm.On("EnsureTags", ctx, desired, scmd).Return(nil)
+	statusWriter := &ctrlrtclientmock.SubResourceWriter{}
+	kc.On("Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch")).Return(nil)
+	kc.On("Status").Return(statusWriter)
+	statusWriter.On("Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch")).Return(nil)
+	_, err := r.Sync(ctx, rm, desired)
+	require.Nil(err)
+	rm.AssertNumberOfCalls(t, "ReadOne", 1)
+	// Assert that the resource is not created or updated
+	rm.AssertNotCalled(t, "Create", 0)
+	rm.AssertNotCalled(t, "Update", 0)
+	rm.AssertNotCalled(t, "Delta", 0)
+}
+
+func TestReconcilerAdoptOrCreateResource_Create(t *testing.T) {
+	require := require.New(t)
+
+	ctx := context.TODO()
+	// arn := ackv1alpha1.AWSResourceName("my-adopt-book-arn")
+
+	desired, _, metaObj := resourceMocks()
+	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	metaObj.SetAnnotations(map[string]string{
+		ackv1alpha1.AnnotationAdoptionPolicy: "adopt-or-create",
+		ackv1alpha1.AnnotationAdoptionFields: "{\"arn\": \"my-adopt-book-arn\"}",
+	})
+
+	ids := &ackmocks.AWSResourceIdentifiers{}
+	// ids.On("ARN").Return(&arn)
+
+	latest, latestRTObj, _ := resourceMocks()
+	latest.On("Identifiers").Return(ids)
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On("MetaObject").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
+			ackv1alpha1.AnnotationAdoptionFields: "{\"arn\": \"my-adopt-book-arn\"}",
+		},
+	})
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return()
+
+	rm := &ackmocks.AWSResourceManager{}
+	rm.On("ResolveReferences", ctx, nil, desired).Return(
+		desired, false, nil,
+	).Times(2)
+	rm.On("ClearResolvedReferences", desired).Return(desired)
+	rm.On("ClearResolvedReferences", latest).Return(latest)
+	rm.On("ReadOne", ctx, desired).Return(
+		nil, ackerr.NotFound,
+	).Once()
+	rm.On("ReadOne", ctx, latest).Return(
+		latest, nil,
+	)
+	rm.On("Create", ctx, desired).Return(
+		latest, nil,
+	).Once()
+	rm.On("IsSynced", ctx, latest).Return(true, nil)
+	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
+
+	rm.On("LateInitialize", ctx, latest).Return(latest, nil)
+	rd.On("IsManaged", desired).Return(false).Once()
+	rd.On("IsManaged", desired).Return(true)
+	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
+	rd.On("Delta", latest, latest).Return(ackcompare.NewDelta())
+
+	r, kc, scmd := reconcilerMocks(rmf)
+	rm.On("EnsureTags", ctx, desired, scmd).Return(nil)
+	statusWriter := &ctrlrtclientmock.SubResourceWriter{}
+	kc.On("Status").Return(statusWriter)
+	kc.On("Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch")).Return(nil)
+	statusWriter.On("Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch")).Return(nil)
+	_, err := r.Sync(ctx, rm, desired)
+	require.Nil(err)
+	rm.AssertNumberOfCalls(t, "ReadOne", 2)
+	rm.AssertNumberOfCalls(t, "Create", 1)
+	// Assert that the resource is not created or updated
+	rm.AssertNotCalled(t, "Update", 0)
+	rm.AssertNotCalled(t, "Delta", 0)
+}
+
+func TestReconcilerAdoptOrCreateResource_Adopt(t *testing.T) {
+	require := require.New(t)
+
+	ctx := context.TODO()
+	// arn := ackv1alpha1.AWSResourceName("my-adopt-book-arn")
+
+	desired, _, metaObj := resourceMocks()
+	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	metaObj.SetAnnotations(map[string]string{
+		ackv1alpha1.AnnotationAdoptionPolicy: "adopt-or-create",
+		ackv1alpha1.AnnotationAdoptionFields: "{\"arn\": \"my-adopt-book-arn\"}",
+	})
+
+	ids := &ackmocks.AWSResourceIdentifiers{}
+	// ids.On("ARN").Return(&arn)
+	delta := ackcompare.NewDelta()
+	delta.Add("Spec.A", "val1", "val2")
+
+	latest, latestRTObj, _ := resourceMocks()
+	latest.On("Identifiers").Return(ids)
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On("MetaObject").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
+			ackv1alpha1.AnnotationAdoptionFields: "{\"arn\": \"my-adopt-book-arn\"}",
+		},
+	})
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return()
+
+	rm := &ackmocks.AWSResourceManager{}
+	rm.On("ResolveReferences", ctx, nil, desired).Return(
+		desired, false, nil,
+	).Times(2)
+	rm.On("ClearResolvedReferences", desired).Return(desired)
+	rm.On("ClearResolvedReferences", latest).Return(latest)
+	rm.On("ReadOne", ctx, desired).Return(
+		latest, nil,
+	).Once()
+	rm.On("Update", ctx, desired, latest, delta).Return(
+		latest, nil,
+	).Once()
+	rm.On("IsSynced", ctx, latest).Return(true, nil)
+	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
+
+	rm.On("LateInitialize", ctx, latest).Return(latest, nil)
+	rd.On("IsManaged", desired).Return(true)
+	rd.On("Delta", desired, latest).Return(
+		delta,
+	).Once()
+	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
+	rd.On("Delta", latest, latest).Return(ackcompare.NewDelta())
+
+	r, kc, scmd := reconcilerMocks(rmf)
+	rm.On("EnsureTags", ctx, desired, scmd).Return(nil)
+	statusWriter := &ctrlrtclientmock.SubResourceWriter{}
+	kc.On("Status").Return(statusWriter)
+	kc.On("Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch")).Return(nil)
+	statusWriter.On("Patch", ctx, latestRTObj, mock.AnythingOfType("*client.mergeFromPatch")).Return(nil)
+	_, err := r.Sync(ctx, rm, desired)
+	require.Nil(err)
+	rm.AssertNumberOfCalls(t, "ReadOne", 1)
+	rm.AssertCalled(t, "Update", ctx, desired, latest, delta)
+	rd.AssertCalled(t, "Delta", desired, latest)
+	// Assert that the resource is not created or updated
+	rm.AssertNumberOfCalls(t, "Create", 0)
+}
+
 func TestReconcilerCreate_UnManagedResource_CheckReferencesResolveOnce(t *testing.T) {
 	require := require.New(t)
 

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -324,7 +324,6 @@ func TestReconcilerAdoptOrCreateResource_Create(t *testing.T) {
 	require := require.New(t)
 
 	ctx := context.TODO()
-	// arn := ackv1alpha1.AWSResourceName("my-adopt-book-arn")
 
 	desired, _, metaObj := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
@@ -334,7 +333,6 @@ func TestReconcilerAdoptOrCreateResource_Create(t *testing.T) {
 	})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
-	// ids.On("ARN").Return(&arn)
 
 	latest, latestRTObj, _ := resourceMocks()
 	latest.On("Identifiers").Return(ids)
@@ -394,7 +392,6 @@ func TestReconcilerAdoptOrCreateResource_Adopt(t *testing.T) {
 	require := require.New(t)
 
 	ctx := context.TODO()
-	// arn := ackv1alpha1.AWSResourceName("my-adopt-book-arn")
 
 	desired, _, metaObj := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
@@ -404,7 +401,6 @@ func TestReconcilerAdoptOrCreateResource_Adopt(t *testing.T) {
 	})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
-	// ids.On("ARN").Return(&arn)
 	delta := ackcompare.NewDelta()
 	delta.Add("Spec.A", "val1", "val2")
 

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -32,11 +32,12 @@ import (
 // TODO(michaelhtm) Maybe we need a different place for this...
 // next refactor maybe? 🤷‍♂️
 type AdoptionPolicy string
+
 const (
-	PolicyAdopt AdoptionPolicy = "adopt"
-	// calling this policy constant `Magic`
+	AdoptPolicy AdoptionPolicy = "adopt"
+	// calling this policy constant `AdoptOrCreatePolicy`
 	//  and see if we need to rename it!!!
-	Magic AdoptionPolicy = "adopt-or-create"
+	AdoptOrCreatePolicy AdoptionPolicy = "adopt-or-create"
 )
 
 // IsAdopted returns true if the supplied AWSResource was created with a
@@ -99,7 +100,7 @@ func GetAdoptionPolicy(res acktypes.AWSResource) (AdoptionPolicy, error) {
 		return "", nil
 	}
 
-	if policy != string(PolicyAdopt) && policy != string(Magic) {
+	if policy != string(AdoptPolicy) && policy != string(AdoptOrCreatePolicy) {
 		return "", fmt.Errorf("unrecognized adoption policy")
 	}
 

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -29,15 +29,16 @@ import (
 
 // AdoptionPolicy stores adoptionPolicy values we expect users to
 // provide in the resources `adoption-policy` annotation
+//
 // TODO(michaelhtm) Maybe we need a different place for this...
 // next refactor maybe? 🤷‍♂️
 type AdoptionPolicy string
 
 const (
-	AdoptPolicy AdoptionPolicy = "adopt"
-	// calling this policy constant `AdoptOrCreatePolicy`
-	//  and see if we need to rename it!!!
-	AdoptOrCreatePolicy AdoptionPolicy = "adopt-or-create"
+	// AdoptPolicy is ...
+	AdoptionPolicy_Adopt AdoptionPolicy = "adopt"
+	// AdoptPolicy is ...
+	AdoptionPolicy_AdoptOrCreate AdoptionPolicy = "adopt-or-create"
 )
 
 // IsAdopted returns true if the supplied AWSResource was created with a
@@ -100,7 +101,7 @@ func GetAdoptionPolicy(res acktypes.AWSResource) (AdoptionPolicy, error) {
 		return "", nil
 	}
 
-	if policy != string(AdoptPolicy) && policy != string(AdoptOrCreatePolicy) {
+	if policy != string(AdoptionPolicy_Adopt) && policy != string(AdoptionPolicy_AdoptOrCreate) {
 		return "", fmt.Errorf("unrecognized adoption policy")
 	}
 

--- a/pkg/runtime/util_test.go
+++ b/pkg/runtime/util_test.go
@@ -74,7 +74,7 @@ func TestIsForcedAdoption(t *testing.T) {
 	res := &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
 		Annotations: map[string]string{
-			ackv1alpha1.AnnotationAdoptionPolicy: "true",
+			ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
 			ackv1alpha1.AnnotationAdopted:        "false",
 		},
 	})
@@ -83,7 +83,7 @@ func TestIsForcedAdoption(t *testing.T) {
 	res = &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
 		Annotations: map[string]string{
-			ackv1alpha1.AnnotationAdoptionPolicy: "true",
+			ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
 			ackv1alpha1.AnnotationAdopted:        "true",
 		},
 	})
@@ -92,7 +92,6 @@ func TestIsForcedAdoption(t *testing.T) {
 	res = &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
 		Annotations: map[string]string{
-			ackv1alpha1.AnnotationAdoptionPolicy: "false",
 			ackv1alpha1.AnnotationAdopted:        "true",
 		},
 	})


### PR DESCRIPTION
Issue [#2406](https://github.com/aws-controllers-k8s/community/issues/2406)

Description of changes:
The changes handle the addition of a new `adoption-policy` called `adopt-or-create`.
The adopt-or-create policy requires users to define the Spec fields in the resource Spec,
and the Status fields in the `adoption-fields` annotation. Requiring the Spec fields be in Spec
for adopt-or-create ensures that the users provide fields that may also be required for a create
operation. 

Here is the controller lifecycle of adopt-or-create policy:
```
Controller looks for resource in AWS
If found
   check if there are any differences between user resource definition (desired) and 
    resource definition in AWS (latest). Update if there are any differences
If not Found
  create the resource
```
Unlike the `adopt` adoption policy, if a resource has `adopt-or-create` policy and `read-only`, and it is not found 
in AWS, the controller will mark that resource with a terminal error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
