### PR TITLE
fix: patch metadata and spec during Adopt adoption

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -466,6 +466,12 @@ func (r *resourceReconciler) Sync(
 	rlog.Exit("rm.ReadOne", err)
 	if err != nil {
 		if err != ackerr.NotFound {
+			if adoptionPolicy == AdoptionPolicy_Adopt && latest != nil {
+				latest, err = r.patchResourceMetadataAndSpec(ctx, rm, desired, latest)
+				if err != nil {
+					return latest, err
+				}
+			}
 			return latest, err
 		}
 		if adoptionPolicy == AdoptionPolicy_Adopt || isAdopted {


### PR DESCRIPTION
Description of changes:
Currently, when adoptionPolicy is `adopt`, when you call ReadOne 
if the resource is found but there is an error (Eg. Resource 
is not synced), the Spec fields do not get patched.

These changes ensure if the resource is found, even with errors, we 
patch the Spec with latest fields

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
