### PR TITLE
fix: ensure Status fields are populated!

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -446,6 +446,7 @@ func (r *resourceReconciler) Sync(
 		}
 		if adoptionPolicy == AdoptionPolicy_AdoptOrCreate {
 			// here we assume the spec fields are provided in the spec.
+			resolved = resolved.DeepCopy()
 			resolved.SetStatus(populated)
 		} else {
 			resolved = populated


### PR DESCRIPTION
Issue [#2459](https://github.com/aws-controllers-k8s/community/issues/2459)

Description of changes:
When we have adopt-or-create, the populated status was not 
getting patched to k8s. So, during the next reconcile, the controller 
attempts to recreate the resource.

With this fix, we ensure that the controller does patch the resource with 
the adoption field!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
