### PR TITLE
fix: ensure we mark resource as adopted adopt-or-create

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -732,8 +732,7 @@ func (r *resourceReconciler) updateResource(
 	rm acktypes.AWSResourceManager,
 	desired acktypes.AWSResource,
 	latest acktypes.AWSResource,
-) (acktypes.AWSResource, error) {
-	var err error
+) (updated acktypes.AWSResource, err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("r.updateResource")
 	defer func() {
@@ -754,21 +753,24 @@ func (r *resourceReconciler) updateResource(
 			"diff", delta.Differences,
 		)
 		rlog.Enter("rm.Update")
-		latest, err = rm.Update(ctx, desired, latest, delta)
+		updated, err = rm.Update(ctx, desired, latest, delta)
 		rlog.Exit("rm.Update", err, "latest", latest)
 		if err != nil {
-			return latest, err
+			return updated, err
 		}
 		// Ensure that we are patching any changes to the annotations/metadata and
 		// the Spec that may have been set by the resource manager's successful
 		// Update call above.
-		latest, err = r.patchResourceMetadataAndSpec(ctx, rm, desired, latest)
+		if IsAdopted(latest) {
+			r.rd.MarkAdopted(updated)
+		}
+		updated, err = r.patchResourceMetadataAndSpec(ctx, rm, desired, updated)
 		if err != nil {
-			return latest, err
+			return updated, err
 		}
 		rlog.Info("updated resource")
 	}
-	return latest, nil
+	return updated, nil
 }
 
 // lateInitializeResource calls AWSResourceManager.LateInitialize() method and


### PR DESCRIPTION
Issue [#2459#issuecomment-2879691276](https://github.com/aws-controllers-k8s/community/issues/2459#issuecomment-2879691276)

Description of changes:
Currently the `adopted` annotation was getting removed when the resource
goes through update path during adopt-or-create adoption. These changes
ensure the annotation is persisted in k8s.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
