### PR TITLE
fix: Ensure feature gates are enabled for unit tests

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -488,7 +488,9 @@ func (r *resourceReconciler) Sync(
 		if err != nil {
 			return latest, err
 		}
-	} else if !isReadOnly {
+	} else if isReadOnly {
+		return latest, nil
+	} else {
 		if adoptionPolicy == AdoptionPolicy_AdoptOrCreate {
 			// set adopt-or-create resource as managed before attempting
 			// update


### PR DESCRIPTION
Description of changes:
Extra changes:
* Ensure lateInitialize is not called for readOnly policy
* Add mock call for PopulateResourceFromAnnotation in adopt tests
* Ensure FilterSystemTags is called for `adopt` policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
