### PR TITLE
ACK Sharding: "Invalidate" cache after moving between shards

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	ResourceTags                    []string
 	WatchNamespace                  string
 	WatchSelectors                  string
+	WatchSelectorsParsed            labels.Selector
 	EnableWebhookServer             bool
 	WebhookServerAddr               string
 	DeletionPolicy                  ackv1alpha1.DeletionPolicy
@@ -489,7 +490,8 @@ func (cfg *Config) ParseWatchSelectors() (labels.Selector, error) {
 	// If the WatchSelectors isn't set, return nil. controller-runtime will be in charge
 	// of defaulting to watching all objects.
 	if cfg.WatchSelectors == "" {
-		return nil, nil
+		cfg.WatchSelectorsParsed = labels.Everything()
+		return labels.Everything(), nil
 	}
 
 	labelSelector, err := labels.Parse(cfg.WatchSelectors)
@@ -497,6 +499,8 @@ func (cfg *Config) ParseWatchSelectors() (labels.Selector, error) {
 		return nil, fmt.Errorf("invalid value for flag '%s': %v", flagWatchSelectors, err)
 	}
 
+	// Set the parsed label selector in the Config struct for later use
+	cfg.WatchSelectorsParsed = labelSelector
 	return labelSelector, nil
 }
 

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -215,7 +215,7 @@ func (r *resourceReconciler) Reconcile(ctx context.Context, req ctrlrt.Request) 
 		return ctrlrt.Result{}, err
 	}
 
-	// Check if the resource still matched the the watchSelectors.
+	// Check if the resource still matches the watchSelectors.
 	if !r.cfg.WatchSelectorsParsed.Matches(labels.Set(desired.MetaObject().GetLabels())) {
 		r.log.V(1).Info(
 			"Skipping reconcile for resource that does not match watch selectors",


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/2545

Description of changes:

Due to the limitation (or design implementation) of k8s controller-runtime library, we have no control to hot reload / invalidate the cache of resources if a resource's labels are changed, for example.

In the sharding context of ACK controllers, by checking if that resource (from cache) still belongs to that controller, we ensure that 2 or more controllers will not overlap between each other in the context of moving a resource from one shard to another.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
