### PR TITLE
feat: retrieve aws partition from callerIdentity

### DIFF
--- a/apis/core/v1alpha1/common.go
+++ b/apis/core/v1alpha1/common.go
@@ -16,6 +16,9 @@ package v1alpha1
 // AWSRegion represents an AWS regional identifier
 type AWSRegion string
 
+// AWSPartition represents an AWS partition identifier
+type AWSPartition string
+
 // AWSAccountID represents an AWS account identifier
 type AWSAccountID string
 

--- a/apis/core/v1alpha1/resource_metadata.go
+++ b/apis/core/v1alpha1/resource_metadata.go
@@ -32,5 +32,7 @@ type ResourceMetadata struct {
 	OwnerAccountID *AWSAccountID `json:"ownerAccountID"`
 	// Region is the AWS region in which the resource exists or will exist.
 	Region *AWSRegion `json:"region"`
+	// Partition is the AWS partition in which the resource exists or will exist
+	Partition *AWSPartition `json:"partition"`
 }
 

--- a/mocks/pkg/types/aws_resource_identifiers.go
+++ b/mocks/pkg/types/aws_resource_identifiers.go
@@ -53,6 +53,26 @@ func (_m *AWSResourceIdentifiers) OwnerAccountID() *v1alpha1.AWSAccountID {
 	return r0
 }
 
+// Partition provides a mock function with no fields
+func (_m *AWSResourceIdentifiers) Partition() *v1alpha1.AWSPartition {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Partition")
+	}
+
+	var r0 *v1alpha1.AWSPartition
+	if rf, ok := ret.Get(0).(func() *v1alpha1.AWSPartition); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.AWSPartition)
+		}
+	}
+
+	return r0
+}
+
 // Region provides a mock function with no fields
 func (_m *AWSResourceIdentifiers) Region() *v1alpha1.AWSRegion {
 	ret := _m.Called()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/jaypipes/envutil"
@@ -94,6 +95,7 @@ type Config struct {
 	LeaderElectionNamespace         string
 	EnableDevelopmentLogging        bool
 	AccountID                       string
+	Partition                       string
 	Region                          string
 	IdentityEndpointURL             string
 	EndpointURL                     string
@@ -296,9 +298,10 @@ func (cfg *Config) SetupLogger() {
 	klog.SetLogger(logger)
 }
 
-// SetAWSAccountID uses sts GetCallerIdentity API to find AWS AccountId and set
-// in Config
-func (cfg *Config) SetAWSAccountID(ctx context.Context) error {
+// SetAWSAccountInfo uses sts GetCallerIdentity API to find AWS AccountId and partition
+//
+//	to set in Config
+func (cfg *Config) SetAWSAccountInfo(ctx context.Context) error {
 	awsCfg, err := config.LoadDefaultConfig(
 		ctx,
 		config.WithRegion(cfg.Region),
@@ -316,6 +319,14 @@ func (cfg *Config) SetAWSAccountID(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to get caller identity: %v", err)
 	}
+	if res.Arn == nil {
+		return fmt.Errorf("caller identity response missing ARN")
+	}
+	parsedARN, err := arn.Parse(*res.Arn)
+	if err != nil {
+		return fmt.Errorf("error parsing arn: %v", err)
+	}
+	cfg.Partition = parsedARN.Partition
 	cfg.AccountID = *res.Account
 	return nil
 }
@@ -369,8 +380,8 @@ func (cfg *Config) Validate(ctx context.Context, options ...Option) error {
 		}
 	}
 
-	if err := cfg.SetAWSAccountID(ctx); err != nil {
-		return fmt.Errorf("unable to determine account ID: %v", err)
+	if err := cfg.SetAWSAccountInfo(ctx); err != nil {
+		return fmt.Errorf("unable to determine account info: %v", err)
 	}
 
 	if cfg.EnableWebhookServer && cfg.WebhookServerAddr == "" {

--- a/pkg/types/aws_resource_identifiers.go
+++ b/pkg/types/aws_resource_identifiers.go
@@ -29,4 +29,6 @@ type AWSResourceIdentifiers interface {
 	ARN() *ackv1alpha1.AWSResourceName
 	// Region is the AWS region in which the resource exists or will exist.
 	Region() *ackv1alpha1.AWSRegion
+	// Partition is the AWS partition in which the resource exists or will exist.
+	Partition() *ackv1alpha1.AWSPartition
 }


### PR DESCRIPTION
Description of changes:
Retrieve Partition from sts Caller identity. This will help with the generation of 
ACK resource status, adding support for all partitions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
