### PR TITLE
Initial implementation for Ready condition

### DIFF
--- a/apis/core/v1alpha1/conditions.go
+++ b/apis/core/v1alpha1/conditions.go
@@ -23,6 +23,9 @@ import (
 type ConditionType string
 
 const (
+	// Ready condition means "ready to use" plus a minimal set of subconditions for specific states.
+	// Ready condition reason field with carry important information such as Creating, Updating, PermissionDenied, InvalidConfiguration etc...
+	ConditionTypeReady ConditionType = "Ready"
 	// ConditionTypeAdopted indicates that the adopted resource custom resource
 	// has been successfully reconciled and the target has been created
 	ConditionTypeAdopted ConditionType = "ACK.Adopted"

--- a/mocks/pkg/types/aws_resource_reconciler.go
+++ b/mocks/pkg/types/aws_resource_reconciler.go
@@ -40,6 +40,11 @@ func (_m *AWSResourceReconciler) BindControllerManager(_a0 manager.Manager) erro
 	return r0
 }
 
+// EnsureReadyCondition provides a mock function with given fields: ctx, res
+func (_m *AWSResourceReconciler) EnsureReadyCondition(ctx context.Context, res types.AWSResource) {
+	_m.Called(ctx, res)
+}
+
 // GroupVersionKind provides a mock function with no fields
 func (_m *AWSResourceReconciler) GroupVersionKind() *schema.GroupVersionKind {
 	ret := _m.Called()

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -29,7 +29,7 @@ var (
 	NotManagedReason  = "This resource already exists but is not managed by ACK. " +
 		"To bring the resource under ACK management, you should explicitly adopt " +
 		"the resource by enabling the ResourceAdoption feature gate and populating " +
-		"the `services.k8s.aws/adoption-policy` and `services.k8s.aws/adoption-fields` " + 
+		"the `services.k8s.aws/adoption-policy` and `services.k8s.aws/adoption-fields` " +
 		"annotations."
 	UnknownSyncedMessage             = "Unable to determine if desired resource state matches latest observed state"
 	NotSyncedMessage                 = "Resource not synced"
@@ -50,6 +50,10 @@ func Synced(subject acktypes.ConditionManager) *ackv1alpha1.Condition {
 // nil.
 func Terminal(subject acktypes.ConditionManager) *ackv1alpha1.Condition {
 	return FirstOfType(subject, ackv1alpha1.ConditionTypeTerminal)
+}
+
+func Ready(subject acktypes.ConditionManager) *ackv1alpha1.Condition {
+	return FirstOfType(subject, ackv1alpha1.ConditionTypeReady)
 }
 
 // Recoverable returns the Condition in the resource's Conditions collection
@@ -115,6 +119,28 @@ func SetSynced(
 	if c = Synced(subject); c == nil {
 		c = &ackv1alpha1.Condition{
 			Type: ackv1alpha1.ConditionTypeResourceSynced,
+		}
+		allConds = append(allConds, c)
+	}
+	now := metav1.Now()
+	c.LastTransitionTime = &now
+	c.Status = status
+	c.Message = message
+	c.Reason = reason
+	subject.ReplaceConditions(allConds)
+}
+
+func SetReady(
+	subject acktypes.ConditionManager,
+	status corev1.ConditionStatus,
+	message *string,
+	reason *string,
+) {
+	allConds := subject.Conditions()
+	var c *ackv1alpha1.Condition
+	if c = Ready(subject); c == nil {
+		c = &ackv1alpha1.Condition{
+			Type: ackv1alpha1.ConditionTypeReady,
 		}
 		allConds = append(allConds, c)
 	}

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -505,7 +505,7 @@ func TestReconcilerAdoptOrCreateResource_Adopt(t *testing.T) {
 	latest, latestRTObj, latestMetaObj := resourceMocks()
 	latest.On("Identifiers").Return(ids)
 	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
-		latest.On(
+	latest.On(
 		"ReplaceConditions",
 		mock.AnythingOfType("[]*v1alpha1.Condition"),
 	).Return().Run(func(args mock.Arguments) {
@@ -521,6 +521,22 @@ func TestReconcilerAdoptOrCreateResource_Adopt(t *testing.T) {
 			assert.Equal(ackcondition.SyncedMessage, *condition.Message)
 		}
 		assert.True(hasSynced)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		hasReady := false
+		for _, condition := range conditions {
+			if condition.Type != ackv1alpha1.ConditionTypeReady {
+				continue
+			}
+
+			hasReady = true
+		}
+		assert.True(hasReady)
 	})
 	latestMetaObj.SetAnnotations(map[string]string{
 		ackv1alpha1.AnnotationAdoptionPolicy: "adopt-or-create",
@@ -617,6 +633,16 @@ func TestReconcilerCreate_UnManagedResource_CheckReferencesResolveOnce(t *testin
 		cond := conditions[0]
 		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
 		assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -700,6 +726,16 @@ func TestReconcilerCreate_ManagedResource_CheckReferencesResolveOnce(t *testing.
 		cond := conditions[0]
 		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
 		assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -783,6 +819,16 @@ func TestReconcilerUpdate(t *testing.T) {
 		cond := conditions[0]
 		assert.Equal(t, ackv1alpha1.ConditionTypeResourceSynced, cond.Type)
 		assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -870,6 +916,16 @@ func TestReconcilerUpdate_ResourceNotSynced(t *testing.T) {
 		// False
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 		assert.Equal(t, ackcondition.NotSyncedMessage, *cond.Message)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -954,6 +1010,16 @@ func TestReconcilerUpdate_NoDelta_ResourceNotSynced(t *testing.T) {
 		// False
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 		assert.Equal(t, ackcondition.NotSyncedMessage, *cond.Message)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -1033,6 +1099,16 @@ func TestReconcilerUpdate_NoDelta_ResourceSynced(t *testing.T) {
 		// True
 		assert.Equal(t, corev1.ConditionTrue, cond.Status)
 		assert.Equal(t, ackcondition.SyncedMessage, *cond.Message)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -1116,6 +1192,16 @@ func TestReconcilerUpdate_IsSyncedError(t *testing.T) {
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 		assert.Equal(t, ackcondition.NotSyncedMessage, *cond.Message)
 		assert.Equal(t, syncedError.Error(), *cond.Reason)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -1275,6 +1361,22 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInSpec(t *testing.T) {
 			assert.Equal(ackcondition.SyncedMessage, *condition.Message)
 		}
 		assert.True(hasSynced)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		hasReady := false
+		for _, condition := range conditions {
+			if condition.Type != ackv1alpha1.ConditionTypeReady {
+				continue
+			}
+
+			hasReady = true
+		}
+		assert.True(hasReady)
 	})
 	// Note no change to metadata...
 
@@ -1425,6 +1527,22 @@ func TestReconcilerUpdate_ErrorInLateInitialization(t *testing.T) {
 			assert.Equal(requeueError.Error(), *condition.Reason)
 		}
 		assert.True(hasSynced)
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		hasReady := false
+		for _, condition := range conditions {
+			if condition.Type != ackv1alpha1.ConditionTypeReady {
+				continue
+			}
+
+			hasReady = true
+		}
+		assert.True(hasReady)
 	})
 
 	rm := &ackmocks.AWSResourceManager{}
@@ -1545,7 +1663,23 @@ func TestReconcilerUpdate_ResourceNotManaged(t *testing.T) {
 			assert.Equal(ackcondition.NotSyncedMessage, *condition.Message)
 		}
 		assert.True(hasSynced)
-	})
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		hasReady := false
+		for _, condition := range conditions {
+			if condition.Type != ackv1alpha1.ConditionTypeReady {
+				continue
+			}
+
+			hasReady = true
+		}
+		assert.True(hasReady)
+	}).Once()
 
 	rm := &ackmocks.AWSResourceManager{}
 	rmf, rd := managerFactoryMocks(desired, latest, false)
@@ -1700,7 +1834,17 @@ func TestReconcilerUpdate_EnsureControllerTagsError(t *testing.T) {
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 		assert.Equal(t, ackcondition.NotSyncedMessage, *cond.Message)
 		assert.Equal(t, ensureControllerTagsError.Error(), *cond.Reason)
-	})
+	}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
+	}).Once()
 
 	rm := &ackmocks.AWSResourceManager{}
 	rm.On("ResolveReferences", ctx, nil, desired).Return(desired, false, nil)
@@ -1747,4 +1891,30 @@ func TestReconcilerUpdate_EnsureControllerTagsError(t *testing.T) {
 	kc.AssertNotCalled(t, "Status")
 	rm.AssertNotCalled(t, "LateInitialize", ctx, latest)
 	rm.AssertCalled(t, "EnsureTags", ctx, desired, scmd)
+}
+
+func TestEnsureReadyCondition_EnsureReadyConditionExist(t *testing.T) {
+
+	ctx := context.TODO()
+	desired, _, _ := resourceMocks()
+
+	latest, _, _ := resourceMocks()
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{{Type: ackv1alpha1.ConditionTypeResourceSynced, Status: corev1.ConditionTrue}}).Once()
+	latest.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return().Once()
+	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	latest.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		assert.Equal(t, 1, len(conditions))
+		cond := conditions[0]
+		assert.Equal(t, ackv1alpha1.ConditionTypeReady, cond.Type)
+		assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	})
+
+	rmf, _ := managedResourceManagerFactoryMocks(desired, latest)
+	r, _, _ := reconcilerMocks(rmf)
+
+	r.EnsureReadyCondition(ctx, latest)
 }

--- a/pkg/types/aws_resource_reconciler.go
+++ b/pkg/types/aws_resource_reconciler.go
@@ -64,4 +64,8 @@ type AWSResourceReconciler interface {
 		latest AWSResource,
 		err error,
 	) (ctrlrt.Result, error)
+	// NOTE: This is really only here for dependency injection
+	// purposes in unit testing in order to simplify test setups.
+	EnsureReadyCondition(ctx context.Context,
+		res AWSResource)
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Updating reconcile logic to translate existing ```ACK.*``` conditions into single ready condition
Hide existing conditions, expose only Ready

* Add the Ready condition
* Remove redundant conditions like ACK.Terminal/ACK.Recoverable 
* Simple change to the code base, controller logic unchanged

Testing: Sample bucket resource with new ready condition

```
kubectl describe bucket my-ack-s3-bucket-822779886699                      
Name:         my-ack-s3-bucket-822779886699
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  s3.services.k8s.aws/v1alpha1
Kind:         Bucket
Metadata:
  Creation Timestamp:  2025-08-26T02:41:54Z
  Finalizers:
    finalizers.s3.services.k8s.aws/Bucket
  Generation:        1
  Resource Version:  9941823
  UID:               e74c1633-f091-448f-9837-4b3562b4a232
Spec:
  Name:  my-ack-s3-bucket-822779886699
Status:
  Ack Resource Metadata:
    Arn:               arn:aws:s3:::my-ack-s3-bucket-822779886699
    Owner Account ID:  822779886699
    Region:            us-west-2
  Conditions:
    Last Transition Time:  2025-09-16T23:44:42Z
    Message:               Resource synced successfully
    Reason:                
    Status:                True
    Type:                  Ready
  Location:                http://my-ack-s3-bucket-822779886699.s3.amazonaws.com/
Events:                    <none>
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
