### PR TITLE
fix: force disable CARM when only one namespace is watched

### DIFF
--- a/pkg/runtime/service_controller.go
+++ b/pkg/runtime/service_controller.go
@@ -221,8 +221,12 @@ func (c *serviceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg
 		cfg.FeatureGates,
 	)
 	// The caches are only used for cross account resource management. We
-	// want to run them only when --enable-carm is set to true.
-	if cfg.EnableCARM {
+	// want to run them only when --enable-carm is set to true and 
+	// --watch-namespace is set to zero or more than one namespaces.
+	if cfg.EnableCARM && len(namespaces) == 1 {
+		c.log.V(0).Info("--enable-carm is set to true but --watch-namespace is set to a single namespace. CARM will not be enabled.")
+	}
+	if cfg.EnableCARM && (len(namespaces) == 0 || len(namespaces) > 1) {
 		clusterConfig := mgr.GetConfig()
 		clientSet, err := kubernetes.NewForConfig(clusterConfig)
 		if err != nil {


### PR DESCRIPTION
fixes https://github.com/aws-controllers-k8s/community/issues/2625

Description of changes:
- force disables CARM when --watch-namespace has only one namespace even when "--enable-carm" is set to true.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
