### PR TITLE
refactor: convert runtime tests from external to internal package tests

### DIFF
--- a/pkg/runtime/field_export_reconciler_test.go
+++ b/pkg/runtime/field_export_reconciler_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package runtime_test
+package runtime
 
 import (
 	"bytes"
@@ -35,7 +35,6 @@ import (
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
-	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtcache "github.com/aws-controllers-k8s/runtime/pkg/runtime/cache"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -81,7 +80,7 @@ func mockFieldExportReconcilerWithResourceDescriptor(rd *mocks.AWSResourceDescri
 	sc.On("GetResourceManagerFactories").Return(rmFactoryMap)
 	kc := &ctrlrtclientmock.Client{}
 	apiReader := &ctrlrtclientmock.Reader{}
-	return ackrt.NewFieldExportReconcilerWithClient(
+	return NewFieldExportReconcilerWithClient(
 		sc,
 		fakeLogger,
 		cfg,
@@ -253,7 +252,7 @@ func setupMockUnstructuredConverter() {
 		}, nil,
 	)
 	// Update the package variable
-	ackrt.UnstructuredConverter = conv
+	UnstructuredConverter = conv
 }
 
 func mockSourceResource() (

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package runtime_test
+package runtime
 
 import (
 	"context"
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sobj "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8srtschema "k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -41,7 +40,6 @@ import (
 	"github.com/aws-controllers-k8s/runtime/pkg/featuregate"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	"github.com/aws-controllers-k8s/runtime/pkg/requeue"
-	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtcache "github.com/aws-controllers-k8s/runtime/pkg/runtime/cache"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -125,7 +123,7 @@ func reconcilerMocks(
 	sc.On("GetMetadata").Return(scmd)
 	kc := &ctrlrtclientmock.Client{}
 
-	return ackrt.NewReconcilerWithClient(
+	return NewReconcilerWithClient(
 		sc, kc, rmf, fakeLogger, cfg, metrics, ackrtcache.Caches{},
 	), kc, scmd
 }
@@ -150,7 +148,7 @@ func managerFactoryMocks(
 ) {
 	rd := &ackmocks.AWSResourceDescriptor{}
 	rd.On("GroupVersionKind").Return(
-		schema.GroupVersionKind{
+		k8srtschema.GroupVersionKind{
 			Group: "bookstore.services.k8s.aws",
 			Kind:  "fakeBook",
 		},
@@ -164,7 +162,7 @@ func managerFactoryMocks(
 	rmf.On("ResourceDescriptor").Return(rd)
 	rmf.On("RequeueOnSuccessSeconds").Return(0)
 
-	reg := ackrt.NewRegistry()
+	reg := NewRegistry()
 	reg.RegisterResourceManagerFactory(rmf)
 	return rmf, rd
 }

--- a/pkg/runtime/service_controller_test.go
+++ b/pkg/runtime/service_controller_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package runtime_test
+package runtime
 
 import (
 	"context"
@@ -42,7 +42,6 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	mocks "github.com/aws-controllers-k8s/runtime/mocks/pkg/types"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
-	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
@@ -150,7 +149,7 @@ func TestServiceController(t *testing.T) {
 	rmf.On("ResourceDescriptor").Return(rd)
 	rmf.On("RequeueOnSuccessSeconds").Return(0)
 
-	reg := ackrt.NewRegistry()
+	reg := NewRegistry()
 	reg.RegisterResourceManagerFactory(rmf)
 
 	vi := acktypes.VersionInfo{
@@ -159,7 +158,7 @@ func TestServiceController(t *testing.T) {
 		BuildDate:  "now",
 	}
 
-	sc := ackrt.NewServiceController("bookstore", "bookstore.services.k8s.aws", vi)
+	sc := NewServiceController("bookstore", "bookstore.services.k8s.aws", vi)
 	require.NotNil(sc)
 	zapOptions := ctrlrtzap.Options{
 		Development: true,

--- a/pkg/runtime/tags_test.go
+++ b/pkg/runtime/tags_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package runtime_test
+package runtime
 
 import (
 	"fmt"
@@ -21,7 +21,6 @@ import (
 
 	mocks "github.com/aws-controllers-k8s/runtime/mocks/controller-runtime/pkg/client"
 	"github.com/aws-controllers-k8s/runtime/pkg/config"
-	"github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
@@ -42,27 +41,27 @@ func TestGetDefaultTags(t *testing.T) {
 	}
 
 	// nil config
-	assert.Empty(runtime.GetDefaultTags(nil, &obj, md))
+	assert.Empty(GetDefaultTags(nil, &obj, md))
 
 	// nil object
-	assert.Empty(runtime.GetDefaultTags(&cfg, nil, md))
+	assert.Empty(GetDefaultTags(&cfg, nil, md))
 
 	// no resource tags
-	assert.Empty(runtime.GetDefaultTags(&cfg, &obj, md))
+	assert.Empty(GetDefaultTags(&cfg, &obj, md))
 
 	// ill formed tags
 	cfg.ResourceTags = []string{"foobar"}
-	expandedTags := runtime.GetDefaultTags(&cfg, &obj, md)
+	expandedTags := GetDefaultTags(&cfg, &obj, md)
 	assert.Empty(expandedTags)
 
 	// ill formed tags
 	cfg.ResourceTags = []string{"foo=bar=baz"}
-	expandedTags = runtime.GetDefaultTags(&cfg, &obj, md)
+	expandedTags = GetDefaultTags(&cfg, &obj, md)
 	assert.Empty(expandedTags)
 
 	// tags without any ack resource tag format
 	cfg.ResourceTags = []string{"foo=bar"}
-	expandedTags = runtime.GetDefaultTags(&cfg, &obj, md)
+	expandedTags = GetDefaultTags(&cfg, &obj, md)
 	assert.Equal(1, len(expandedTags))
 	assert.Equal("bar", expandedTags["foo"])
 
@@ -80,7 +79,7 @@ func TestGetDefaultTags(t *testing.T) {
 			acktags.ResourceNameTagFormat,
 		),
 	}
-	expandedTags = runtime.GetDefaultTags(&cfg, &obj, md)
+	expandedTags = GetDefaultTags(&cfg, &obj, md)
 	assert.Equal(4, len(expandedTags))
 	assert.Equal("bar", expandedTags["foo"])
 	assert.Equal("s3-v0.0.10", expandedTags["services.k8s.aws/controller-version"])

--- a/pkg/runtime/util_test.go
+++ b/pkg/runtime/util_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package runtime_test
+package runtime
 
 import (
 	"testing"
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 
 	mocks "github.com/aws-controllers-k8s/runtime/mocks/pkg/types"
 )
@@ -35,11 +34,11 @@ func TestIsAdopted(t *testing.T) {
 			ackv1alpha1.AnnotationAdopted: "true",
 		},
 	})
-	require.True(ackrt.IsAdopted(res))
+	require.True(IsAdopted(res))
 
 	res = &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{})
-	require.False(ackrt.IsAdopted(res))
+	require.False(IsAdopted(res))
 }
 
 func TestIsSynced(t *testing.T) {
@@ -52,7 +51,7 @@ func TestIsSynced(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		},
 	})
-	require.True(ackrt.IsSynced(res))
+	require.True(IsSynced(res))
 
 	res = &mocks.AWSResource{}
 	res.On("Conditions").Return([]*ackv1alpha1.Condition{
@@ -65,7 +64,7 @@ func TestIsSynced(t *testing.T) {
 			Status: corev1.ConditionFalse,
 		},
 	})
-	require.False(ackrt.IsSynced(res))
+	require.False(IsSynced(res))
 }
 
 func TestIsForcedAdoption(t *testing.T) {
@@ -78,7 +77,7 @@ func TestIsForcedAdoption(t *testing.T) {
 			ackv1alpha1.AnnotationAdopted:        "false",
 		},
 	})
-	require.True(ackrt.NeedAdoption(res))
+	require.True(NeedAdoption(res))
 
 	res = &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
@@ -87,15 +86,15 @@ func TestIsForcedAdoption(t *testing.T) {
 			ackv1alpha1.AnnotationAdopted:        "true",
 		},
 	})
-	require.False(ackrt.NeedAdoption(res))
+	require.False(NeedAdoption(res))
 
 	res = &mocks.AWSResource{}
 	res.On("MetaObject").Return(&metav1.ObjectMeta{
 		Annotations: map[string]string{
-			ackv1alpha1.AnnotationAdopted:        "true",
+			ackv1alpha1.AnnotationAdopted: "true",
 		},
 	})
-	require.False(ackrt.NeedAdoption(res))
+	require.False(NeedAdoption(res))
 }
 
 func TestExtractAdoptionFields(t *testing.T) {
@@ -115,7 +114,7 @@ func TestExtractAdoptionFields(t *testing.T) {
 		"clusterName": "my-cluster",
 		"name":        "ng-1234",
 	}
-	actual, err := ackrt.ExtractAdoptionFields(res)
+	actual, err := ExtractAdoptionFields(res)
 	require.NoError(err)
 	require.Equal(expected, actual)
 }


### PR DESCRIPTION
Change test files from `runtime_test` to `runtime` package to enable
testing of package private functions. Remove ackrt import alias
as tests now have direct access to runtime package symbols.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
