### PR TITLE
feat: log delta differences for read-only resources when spec changes

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -485,6 +485,14 @@ func (r *resourceReconciler) Sync(
 			return latest, err
 		}
 	} else if isReadOnly {
+		delta := r.rd.Delta(desired, latest)
+		if delta.DifferentAt("Spec") {
+			rlog.Info(
+				"desired resource state has changed, but resource is read-only - skipping update",
+				"skipped", true,
+				"diff", delta.Differences,
+			)
+		}
 		return latest, nil
 	} else {
 		if adoptionPolicy == AdoptionPolicy_AdoptOrCreate {

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -325,12 +325,10 @@ func TestReconcilerReadOnlyResource(t *testing.T) {
 	rm.On("ReadOne", ctx, desired).Return(
 		latest, nil,
 	).Once()
-	rm.On("Create", ctx, desired).Return(
-		latest, nil,
-	)
 	rm.On("IsSynced", ctx, latest).Return(true, nil)
-	rmf, _ := managedResourceManagerFactoryMocks(desired, latest)
-
+	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
+	rd.On("Delta", desired, latest).Return(ackcompare.NewDelta())
+	
 	r, kc, scmd := reconcilerMocks(rmf)
 	rm.On("EnsureTags", ctx, desired, scmd).Return(nil)
 	statusWriter := &ctrlrtclientmock.SubResourceWriter{}
@@ -339,10 +337,10 @@ func TestReconcilerReadOnlyResource(t *testing.T) {
 	_, err := r.Sync(ctx, rm, desired)
 	require.Nil(err)
 	rm.AssertNumberOfCalls(t, "ReadOne", 1)
+	rd.AssertCalled(t, "Delta", desired, latest)
 	// Assert that the resource is not created or updated
 	rm.AssertNotCalled(t, "Create", 0)
 	rm.AssertNotCalled(t, "Update", 0)
-	rm.AssertNotCalled(t, "Delta", 0)
 }
 
 func TestReconcilerAdoptResource(t *testing.T) {
@@ -505,7 +503,7 @@ func TestReconcilerAdoptOrCreateResource_Adopt(t *testing.T) {
 	latest, latestRTObj, latestMetaObj := resourceMocks()
 	latest.On("Identifiers").Return(ids)
 	latest.On("Conditions").Return([]*ackv1alpha1.Condition{})
-		latest.On(
+	latest.On(
 		"ReplaceConditions",
 		mock.AnythingOfType("[]*v1alpha1.Condition"),
 	).Return().Run(func(args mock.Arguments) {


### PR DESCRIPTION
Add informational logging when a read-only resource's desired state 
differs from its current state. This helps operators understand what 
changes would have been applied if the resource wasn't in read-only mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
