### PR TITLE
fix: report resolve references errors for `adopt-or-create`

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -427,8 +427,8 @@ func (r *resourceReconciler) Sync(
 	rlog.Enter("rm.ResolveReferences")
 	resolved, hasReferences, err := rm.ResolveReferences(ctx, r.apiReader, desired)
 	rlog.Exit("rm.ResolveReferences", err)
-	// TODO (michaelhtm): should we fail here for `adopt-or-create` adoption policy?
-	if err != nil && !needAdoption && !isReadOnly {
+	// TODO (michaelhtm): ignore error only for `adopt` or `read-only`
+	if err != nil && (adoptionPolicy == "" || adoptionPolicy == AdoptionPolicy_AdoptOrCreate) && !isReadOnly {
 		return ackcondition.WithReferencesResolvedCondition(desired, err), err
 	}
 	if hasReferences {


### PR DESCRIPTION
Issue [#2641](https://github.com/aws-controllers-k8s/community/issues/2641)

Description of changes:
Currently we have been ignoring `ResolveReferences` errors for all
adoptions and readOnly.

Ignoring the error for `adopt-or-create` is an antipattern, since we want
to ensure users are aware of these issues.

In the case of `adopt`, since the spec will fully be rewritten, we would
not need to resolve references at all.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
