### PR TITLE
fix: avoid returning resolved on error

### DIFF
--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	"github.com/aws-controllers-k8s/runtime/pkg/types"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
@@ -332,4 +333,11 @@ func patchStatus(
 	logger acktypes.Logger,
 ) error {
 	return patchWithRetry(ctx, kc, apiReader, obj, patch, logger, OperationType_Status)
+}
+
+func returnLatestIfNil(observed, latest types.AWSResource) types.AWSResource {
+	if observed == nil {
+		return latest
+	}
+	return observed
 }


### PR DESCRIPTION
Description of changes:
Using resolved as a return value may not always lead to desired results.
When ResolveReferences is called for resources that don't reference any other resources, it returns a direct pointer to the desired resource instead of a copy. This causes an aliasing issue where modifications to the resolved resource inadvertently affect the desired resource.

Impact: When the ACK runtime adds conditions to the resolved resource (particularly on certain errors), these conditions are also applied to the desired resource since both variables point to the same object. This causes the status patch operation to fail detecting any differences, preventing condition updates from being persisted.

With these changes, we will start returning the copy of desired object if the object returned
by the controllers is nil.
If not, we will continue use the returned object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
