### PR TITLE
ensure we set resource conditions to terminal on adoption failure

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -324,6 +324,21 @@ func WithReferencesResolvedCondition(
 	return ko
 }
 
+// WithTerminalCondition returns a new AWSResource with the
+// ConditionTypeTerminal set based on the err parameter
+func WithTerminalCondition(
+	resource acktypes.AWSResource,
+	err error,
+) acktypes.AWSResource {
+	ko := resource.DeepCopy()
+
+	if err != nil {
+		errString := err.Error()
+		SetTerminal(ko, corev1.ConditionTrue, nil, &errString)
+	}
+	return ko
+}
+
 // LateInitializationInProgress return true if ConditionTypeLateInitialized has "False" status
 // False status means that resource has LateInitializationConfig but has not been completely
 // late initialized yet.

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -441,7 +441,7 @@ func (r *resourceReconciler) handlePopulation(
 		if adoptionPolicy == AdoptionPolicy_AdoptOrCreate {
 			return desired, nil
 		}
-		return desired, ackerr.NewTerminalError(err)
+		return ackcondition.WithTerminalCondition(desired, err), ackerr.Terminal
 	}
 
 	populated := desired.DeepCopy()
@@ -554,7 +554,7 @@ func (r *resourceReconciler) Sync(
 	if needAdoption {
 		populated, err := r.handlePopulation(ctx, desired)
 		if err != nil {
-			return nil, err
+			return populated, err
 		}
 		if adoptionPolicy == AdoptionPolicy_AdoptOrCreate {
 			// here we assume the spec fields are provided in the spec.


### PR DESCRIPTION
Description of changes:
With these changes, we ensure failures when parsing adoption fields are reported
in the resource conditions with descriptive error messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
