### PR TITLE
feat: add IAM policy document semantic comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/itchyny/gojq v0.12.6
 	github.com/jaypipes/envutil v1.0.0
+	github.com/micahhausler/aws-iam-policy v0.4.4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/samber/lo v1.37.0
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
@@ -67,7 +67,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/micahhausler/aws-iam-policy v0.4.4 h1:1aMhJ+0CkvUJ8HGN1chX+noXHs8uvGLkD7xIBeYd31c=
+github.com/micahhausler/aws-iam-policy v0.4.4/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -127,8 +129,6 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/samber/lo v1.37.0 h1:XjVcB8g6tgUp8rsPsJ2CvhClfImrpL04YpQHXeHPhRw=
-github.com/samber/lo v1.37.0/go.mod h1:9vaz2O4o8oOnK23pd2TrXufcbdbJIa3b6cstBWKpopA=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -154,8 +154,6 @@ go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
-golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=

--- a/pkg/compare/iam_policy.go
+++ b/pkg/compare/iam_policy.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare
+
+import (
+	"encoding/json"
+	"fmt"
+
+	awsiampolicy "github.com/micahhausler/aws-iam-policy/policy"
+)
+
+// IAMPolicyDocumentEqual returns true if two IAM policy document JSON strings
+// are semantically equivalent. This handles IAM-specific semantics like:
+//   - Statement ordering independence
+//   - Action/Resource as string or array ("s3:Get*" vs ["s3:Get*"])
+//   - Principal variations ("*" vs {"AWS": "*"})
+//   - Condition value comparisons
+//
+// Returns an error if either string cannot be parsed as a valid IAM policy document.
+func IAMPolicyDocumentEqual(desired, latest string) (bool, error) {
+	if desired == latest {
+		return true, nil
+	}
+
+	var desiredPolicy, latestPolicy awsiampolicy.Policy
+
+	if err := json.Unmarshal([]byte(desired), &desiredPolicy); err != nil {
+		return false, fmt.Errorf("failed to parse desired policy document: %w", err)
+	}
+	if err := json.Unmarshal([]byte(latest), &latestPolicy); err != nil {
+		return false, fmt.Errorf("failed to parse latest policy document: %w", err)
+	}
+
+	return desiredPolicy.Equal(&latestPolicy), nil
+}

--- a/pkg/compare/iam_policy_test.go
+++ b/pkg/compare/iam_policy_test.go
@@ -1,0 +1,194 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compare
+
+import (
+	"testing"
+)
+
+func TestIAMPolicyDocumentEqual(t *testing.T) {
+	cases := []struct {
+		name    string
+		a       string
+		b       string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "IdenticalStrings",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+			b:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+			want: true,
+		},
+		{
+			name: "DifferentWhitespace",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+			b: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": "s3:GetObject",
+						"Resource": "*"
+					}
+				]
+			}`,
+			want: true,
+		},
+		{
+			name: "DifferentStatementOrder",
+			a: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{"Sid": "1", "Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"},
+					{"Sid": "2", "Effect": "Deny", "Action": "s3:DeleteObject", "Resource": "*"}
+				]
+			}`,
+			b: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{"Sid": "2", "Effect": "Deny", "Action": "s3:DeleteObject", "Resource": "*"},
+					{"Sid": "1", "Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}
+				]
+			}`,
+			want: true,
+		},
+		{
+			name: "ActionAsStringVsArray",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+			b:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":"*"}]}`,
+			want: true,
+		},
+		{
+			name: "ResourceAsStringVsArray",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"arn:aws:s3:::bucket"}]}`,
+			b:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":["arn:aws:s3:::bucket"]}]}`,
+			want: true,
+		},
+		{
+			name: "DifferentActions",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+			b:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:PutObject","Resource":"*"}]}`,
+			want: false,
+		},
+		{
+			name: "DifferentVersion",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+			b:    `{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+			want: false,
+		},
+		{
+			name: "DifferentStatementCount",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+			b: `{"Version":"2012-10-17","Statement":[
+				{"Effect":"Allow","Action":"s3:*","Resource":"*"},
+				{"Effect":"Deny","Action":"s3:DeleteObject","Resource":"*"}
+			]}`,
+			want: false,
+		},
+		{
+			name:    "InvalidJSONFirst",
+			a:       `{invalid json`,
+			b:       `{"Version":"2012-10-17","Statement":[]}`,
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "InvalidJSONSecond",
+			a:       `{"Version":"2012-10-17","Statement":[]}`,
+			b:       `{invalid json`,
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "WithConditions",
+			a: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:*",
+					"Resource": "*",
+					"Condition": {
+						"StringEquals": {
+							"aws:PrincipalOrgID": "o-123456"
+						}
+					}
+				}]
+			}`,
+			b: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:*",
+					"Resource": "*",
+					"Condition": {
+						"StringEquals": {
+							"aws:PrincipalOrgID": "o-123456"
+						}
+					}
+				}]
+			}`,
+			want: true,
+		},
+		{
+			name: "DifferentConditions",
+			a: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:*",
+					"Resource": "*",
+					"Condition": {
+						"StringEquals": {
+							"aws:PrincipalOrgID": "o-111111"
+						}
+					}
+				}]
+			}`,
+			b: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:*",
+					"Resource": "*",
+					"Condition": {
+						"StringEquals": {
+							"aws:PrincipalOrgID": "o-222222"
+						}
+					}
+				}]
+			}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IAMPolicyDocumentEqual(tc.a, tc.b)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("got %t, want %t", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add `IAMPolicyDocumentEqual()` to compare IAM policy documents
semantically rather than as raw strings. This handles IAM-specific
semantics like statement ordering independence, Action/Resource
as string vs array, and condition value comparisons.

Uses `github.com/micahhausler/aws-iam-policy` for parsing and
comparison logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
