### PR TITLE
fix: improve error message when adoption-fields annotation is missing

### DIFF
--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -495,7 +495,7 @@ func TestReconcilerAdopt_InvalidAdoptionFields_TerminalCondition(t *testing.T) {
 			}
 			hasTerminal = true
 			assert.Equal(corev1.ConditionTrue, condition.Status)
-			assert.Contains(*condition.Message, "unmarshalling adoption-fields annotation")
+			assert.Contains(*condition.Message, "failed to parse services.k8s.aws/adoption-fields annotation as JSON")
 		}
 		assert.True(hasTerminal)
 	}).Once()

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -209,11 +209,18 @@ func NeedAdoption(res acktypes.AWSResource) bool {
 
 func ExtractAdoptionFields(res acktypes.AWSResource) (map[string]string, error) {
 	fields := getAdoptionFields(res)
+	if fields == "" {
+		return nil, fmt.Errorf(
+			"services.k8s.aws/adoption-fields annotation is required when " +
+				"adoption-policy is set to 'adopt'; please provide the resource " +
+				"identifier fields as a JSON object (e.g. '{\"name\": \"my-resource\"}')",
+		)
+	}
 
 	extractedFields := &map[string]string{}
 	err := json.Unmarshal([]byte(fields), extractedFields)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse services.k8s.aws/adoption-fields annotation as JSON: %w", err)
 	}
 
 	return *extractedFields, nil

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -209,11 +209,18 @@ func NeedAdoption(res acktypes.AWSResource) bool {
 
 func ExtractAdoptionFields(res acktypes.AWSResource) (map[string]string, error) {
 	fields := getAdoptionFields(res)
+	if fields == "" {
+		return nil, fmt.Errorf(
+			"services.k8s.aws/adoption-fields annotation is required when " +
+				"adoption-policy is set to 'adopt'; please provide the resource " +
+				"identifier fields as a JSON object (e.g. '{\"name\": \"my-resource\"}')",
+		)
+	}
 
 	extractedFields := &map[string]string{}
 	err := json.Unmarshal([]byte(fields), extractedFields)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshalling adoption-fields annotation: %v", err)
+		return nil, fmt.Errorf("failed to parse services.k8s.aws/adoption-fields annotation as JSON: %w", err)
 	}
 
 	return *extractedFields, nil

--- a/pkg/runtime/util_test.go
+++ b/pkg/runtime/util_test.go
@@ -14,6 +14,7 @@
 package runtime
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -117,4 +118,34 @@ func TestExtractAdoptionFields(t *testing.T) {
 	actual, err := ExtractAdoptionFields(res)
 	require.NoError(err)
 	require.Equal(expected, actual)
+}
+
+func TestExtractAdoptionFields_EmptyFields(t *testing.T) {
+	require := require.New(t)
+
+	// No adoption-fields annotation at all
+	res := &mocks.AWSResource{}
+	res.On("MetaObject").Return(&metav1.ObjectMeta{
+		Annotations: map[string]string{},
+	})
+
+	_, err := ExtractAdoptionFields(res)
+	require.Error(err)
+	require.True(strings.Contains(err.Error(), "services.k8s.aws/adoption-fields annotation is required"))
+	require.True(strings.Contains(err.Error(), "adoption-policy is set to 'adopt'"))
+}
+
+func TestExtractAdoptionFields_InvalidJSON(t *testing.T) {
+	require := require.New(t)
+
+	res := &mocks.AWSResource{}
+	res.On("MetaObject").Return(&metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ackv1alpha1.AnnotationAdoptionFields: `not valid json`,
+		},
+	})
+
+	_, err := ExtractAdoptionFields(res)
+	require.Error(err)
+	require.True(strings.Contains(err.Error(), "failed to parse services.k8s.aws/adoption-fields annotation as JSON"))
 }


### PR DESCRIPTION
## Description

When using `services.k8s.aws/adoption-policy: adopt` without the `services.k8s.aws/adoption-fields` annotation, `ExtractAdoptionFields` in `pkg/runtime/util.go` calls `json.Unmarshal` on an empty string, producing the generic Go error `unexpected end of JSON input`.

This error gives no indication that the `adoption-fields` annotation is missing, making it very difficult to diagnose — especially since it becomes a `TerminalError` that permanently blocks reconciliation.

## Changes

- Added an explicit empty-string check in `ExtractAdoptionFields` that returns a descriptive error message explaining that the `adoption-fields` annotation is required when `adoption-policy` is set to `adopt`
- Wrapped `json.Unmarshal` error with `fmt.Errorf` and `%w` to provide context about which annotation failed to parse
- Added two unit tests for the new error cases

## Before

```
{"level":"error","msg":"Reconciler error","error":"unexpected end of JSON input"}
```

## After

```
{"level":"error","msg":"Reconciler error","error":"services.k8s.aws/adoption-fields annotation is required when adoption-policy is set to 'adopt'; please provide the resource identifier fields as a JSON object (e.g. '{\"name\": \"my-resource\"}')"}
```

## Testing

- Unit tests added and passing (`go test ./pkg/runtime/...`)
- Manually verified with ACK IAM Controller v1.6.2 on EKS

Fixes aws-controllers-k8s/community#2824

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.