### PR TITLE
feat: add config option to enable path-style URLs for S3 API calls

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,7 @@ const (
 	flagAWSEndpointURL                  = "aws-endpoint-url"
 	flagAWSIdentityEndpointURL          = "aws-identity-endpoint-url"
 	flagUnsafeAWSEndpointURLs           = "allow-unsafe-aws-endpoint-urls"
+	flagAWSEndpointUsePathStyle         = "aws-endpoint-use-path-style"
 	flagLogLevel                        = "log-level"
 	flagResourceTags                    = "resource-tags"
 	flagWatchNamespace                  = "watch-namespace"
@@ -96,6 +97,7 @@ type Config struct {
 	IdentityEndpointURL             string
 	EndpointURL                     string
 	AllowUnsafeEndpointURL          bool
+	UsePathStyle                    bool
 	LogLevel                        string
 	ResourceTags                    []string
 	ResourceTagKeys                 []string
@@ -198,6 +200,11 @@ func (cfg *Config) BindFlags() {
 		&cfg.AllowUnsafeEndpointURL, flagUnsafeAWSEndpointURLs,
 		false,
 		"Allow an unsafe AWS endpoint URL over http",
+	)
+	flag.BoolVar(
+		&cfg.UsePathStyle, flagAWSEndpointUsePathStyle,
+		false,
+		"Force path-style URLs for S3 API calls (e.g. http://host/bucket/key instead of http://bucket.host/key).",
 	)
 	flag.StringVar(
 		&cfg.LogLevel, flagLogLevel,


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#2237

Description of changes:

In order to support some S3-compatible APIs (e.g. LocalStack on a local dev cluster) it may be necessary to force the S3 client to use "path-style" URLs (e.g. http://host/bucket/key).

This PR adds a `UsePathStyle` config field and `--aws-endpoint-use-path-style` CLI flag to force path-style S3 URLs. This will be used by the S3 controller to configure the service client.

Associated PRs:
- [code-generator#684](https://github.com/aws-controllers-k8s/code-generator/pull/684) adds a necessary hook to allow configuring the service client based on this config option.
- [s3-controller#214](https://github.com/aws-controllers-k8s/s3-controller/pull/214) uses the hook created in the `code-generator` PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
