### PR TITLE
fix: report adoption errors as Terminal conditions

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -324,6 +324,21 @@ func WithReferencesResolvedCondition(
 	return ko
 }
 
+// WithTerminalCondition returns a new AWSResource with the
+// ConditionTypeTerminal set based on the err parameter
+func WithTerminalCondition(
+	resource acktypes.AWSResource,
+	err error,
+) acktypes.AWSResource {
+	ko := resource.DeepCopy()
+
+	if err != nil {
+		errString := err.Error()
+		SetTerminal(ko, corev1.ConditionTrue, &errString, nil)
+	}
+	return ko
+}
+
 // LateInitializationInProgress return true if ConditionTypeLateInitialized has "False" status
 // False status means that resource has LateInitializationConfig but has not been completely
 // late initialized yet.

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -451,7 +451,7 @@ func (r *resourceReconciler) handlePopulation(
 	// TODO (michaelhtm) change PopulateResourceFromAnnotation to understand
 	// adopt-or-create, and validate Spec fields are not nil...
 	if err != nil && adoptionPolicy != AdoptionPolicy_AdoptOrCreate {
-		return nil, err
+		return nil, fmt.Errorf("Error populating adoption fields: %v", err)
 	}
 
 	return populated, nil
@@ -528,7 +528,7 @@ func (r *resourceReconciler) Sync(
 	needAdoption := NeedAdoption(desired) && !r.rd.IsManaged(desired) && r.cfg.FeatureGates.IsEnabled(featuregate.ResourceAdoption)
 	adoptionPolicy, err := GetAdoptionPolicy(desired)
 	if err != nil {
-		return nil, err
+		return ackcondition.WithTerminalCondition(desired, err), ackerr.Terminal
 	}
 	if !needAdoption {
 		adoptionPolicy = ""
@@ -554,7 +554,7 @@ func (r *resourceReconciler) Sync(
 	if needAdoption {
 		populated, err := r.handlePopulation(ctx, desired)
 		if err != nil {
-			return nil, err
+			return ackcondition.WithTerminalCondition(desired, err), ackerr.Terminal
 		}
 		if adoptionPolicy == AdoptionPolicy_AdoptOrCreate {
 			// here we assume the spec fields are provided in the spec.

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -410,6 +410,112 @@ func TestReconcilerAdoptResource(t *testing.T) {
 	rm.AssertNotCalled(t, "Delta", 0)
 }
 
+func TestReconcilerAdopt_InvalidAdoptionPolicy_TerminalCondition(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	ctx := context.TODO()
+
+	desired, _, metaObj := resourceMocks()
+	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	metaObj.SetAnnotations(map[string]string{
+		ackv1alpha1.AnnotationAdoptionPolicy: "invalid-policy",
+	})
+
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	desired.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		hasTerminal := false
+		for _, condition := range conditions {
+			if condition.Type != ackv1alpha1.ConditionTypeTerminal {
+				continue
+			}
+			hasTerminal = true
+			assert.Equal(corev1.ConditionTrue, condition.Status)
+			assert.Contains(*condition.Message, "unrecognized adoption policy invalid-policy")
+		}
+		assert.True(hasTerminal)
+	}).Once()
+	desired.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return()
+
+	rm := &ackmocks.AWSResourceManager{}
+	rmf, rd := managerFactoryMocks(desired, nil, false)
+	rd.On("IsManaged", desired).Return(false)
+
+	r, _, scmd := reconcilerMocks(rmf)
+	rm.On("EnsureTags", ctx, desired, scmd).Return(nil)
+
+	latest, err := r.Sync(ctx, rm, desired)
+	require.NotNil(err)
+	assert.Equal(ackerr.Terminal, err)
+	require.NotNil(latest)
+	rm.AssertNotCalled(t, "ResolveReferences")
+	rm.AssertNotCalled(t, "ReadOne")
+	rm.AssertNotCalled(t, "Create")
+	rm.AssertNotCalled(t, "Update")
+}
+
+func TestReconcilerAdopt_InvalidAdoptionFields_TerminalCondition(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	ctx := context.TODO()
+
+	desired, _, metaObj := resourceMocks()
+	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	metaObj.SetAnnotations(map[string]string{
+		ackv1alpha1.AnnotationAdoptionPolicy: "adopt",
+		ackv1alpha1.AnnotationAdoptionFields: "not-valid-json",
+	})
+
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	desired.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return().Run(func(args mock.Arguments) {
+		conditions := args.Get(0).([]*ackv1alpha1.Condition)
+		hasTerminal := false
+		for _, condition := range conditions {
+			if condition.Type != ackv1alpha1.ConditionTypeTerminal {
+				continue
+			}
+			hasTerminal = true
+			assert.Equal(corev1.ConditionTrue, condition.Status)
+			assert.Contains(*condition.Message, "unmarshalling adoption-fields annotation")
+		}
+		assert.True(hasTerminal)
+	}).Once()
+	desired.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return()
+
+	rm := &ackmocks.AWSResourceManager{}
+	rm.On("ResolveReferences", ctx, nil, desired).Return(
+		desired, false, nil,
+	)
+	rm.On("ClearResolvedReferences", desired).Return(desired)
+	rmf, rd := managerFactoryMocks(desired, nil, false)
+	rd.On("IsManaged", desired).Return(false)
+
+	r, _, scmd := reconcilerMocks(rmf)
+	rm.On("EnsureTags", ctx, desired, scmd).Return(nil)
+
+	latest, err := r.Sync(ctx, rm, desired)
+	require.NotNil(err)
+	assert.Equal(ackerr.Terminal, err)
+	require.NotNil(latest)
+	rm.AssertNotCalled(t, "ReadOne")
+	rm.AssertNotCalled(t, "Create")
+	rm.AssertNotCalled(t, "Update")
+}
+
 func TestReconcilerAdoptOrCreateResource_Create(t *testing.T) {
 	require := require.New(t)
 

--- a/pkg/runtime/util.go
+++ b/pkg/runtime/util.go
@@ -194,7 +194,7 @@ func GetAdoptionPolicy(res acktypes.AWSResource) (AdoptionPolicy, error) {
 	}
 
 	if policy != string(AdoptionPolicy_Adopt) && policy != string(AdoptionPolicy_AdoptOrCreate) {
-		return "", fmt.Errorf("unrecognized adoption policy")
+		return "", fmt.Errorf("unrecognized adoption policy %s. Supported policies are \"%s\" and \"%s\"", policy, AdoptionPolicy_Adopt, AdoptionPolicy_AdoptOrCreate)
 	}
 
 	return AdoptionPolicy(policy), nil
@@ -213,7 +213,7 @@ func ExtractAdoptionFields(res acktypes.AWSResource) (map[string]string, error) 
 	extractedFields := &map[string]string{}
 	err := json.Unmarshal([]byte(fields), extractedFields)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshalling adoption-fields annotation: %v", err)
 	}
 
 	return *extractedFields, nil


### PR DESCRIPTION
Description of changes:
Currently, if the user makes a typo when defining the ACK resource
adoption policy or adoption fields, they needed to rely on the logs to
figure out the issue. With these changes, we ensure these errors are
exposed via the resource status with a clear error message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
