### PR TITLE
feat: add --lazy-bind-reconcilers flag for deferred CRD binding

### DIFF
--- a/mocks/pkg/types/aws_resource_descriptor.go
+++ b/mocks/pkg/types/aws_resource_descriptor.go
@@ -73,6 +73,24 @@ func (_m *AWSResourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
 	return r0
 }
 
+// GroupVersionResource provides a mock function with no fields
+func (_m *AWSResourceDescriptor) GroupVersionResource() schema.GroupVersionResource {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GroupVersionResource")
+	}
+
+	var r0 schema.GroupVersionResource
+	if rf, ok := ret.Get(0).(func() schema.GroupVersionResource); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(schema.GroupVersionResource)
+	}
+
+	return r0
+}
+
 // IsManaged provides a mock function with given fields: _a0
 func (_m *AWSResourceDescriptor) IsManaged(_a0 types.AWSResource) bool {
 	ret := _m.Called(_a0)

--- a/mocks/pkg/types/service_controller.go
+++ b/mocks/pkg/types/service_controller.go
@@ -21,17 +21,17 @@ type ServiceController struct {
 	mock.Mock
 }
 
-// BindControllerManager provides a mock function with given fields: _a0, _a1
-func (_m *ServiceController) BindControllerManager(_a0 manager.Manager, _a1 config.Config) error {
-	ret := _m.Called(_a0, _a1)
+// BindControllerManager provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *ServiceController) BindControllerManager(_a0 context.Context, _a1 context.CancelCauseFunc, _a2 manager.Manager, _a3 config.Config) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BindControllerManager")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(manager.Manager, config.Config) error); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, context.CancelCauseFunc, manager.Manager, config.Config) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,8 @@ const (
 	flagReconcileResourceMaxConcurrency = "reconcile-resource-max-concurrent-syncs"
 	flagFeatureGates                    = "feature-gates"
 	flagReconcileResources              = "reconcile-resources"
+	flagLazyBindReconcilers             = "lazy-bind-reconcilers"
+	flagLazyBindRetryInterval           = "lazy-bind-retry-interval"
 	envVarAWSRegion                     = "AWS_REGION"
 )
 
@@ -113,6 +115,8 @@ type Config struct {
 	ReconcileDefaultMaxConcurrency  int
 	ReconcileResourceMaxConcurrency []string
 	ReconcileResources              string
+	LazyBindReconcilers             bool
+	LazyBindRetryInterval           time.Duration
 	// TODO(a-hilaly): migrate to k8s.io/component-base and implement a proper parser for feature gates.
 	FeatureGates    featuregate.FeatureGates
 	featureGatesRaw string
@@ -279,6 +283,17 @@ func (cfg *Config) BindFlags() {
 		"",
 		"A comma-separated list of resource kinds to reconcile. If unspecified, all resources will be reconciled.",
 	)
+	flag.BoolVar(
+		&cfg.LazyBindReconcilers, flagLazyBindReconcilers,
+		false,
+		"When enabled, reconcilers for CRDs that are not yet installed in the cluster will be started "+
+			"in the background once the CRDs become available, instead of failing at startup.",
+	)
+	flag.DurationVar(
+		&cfg.LazyBindRetryInterval, flagLazyBindRetryInterval,
+		10*time.Second,
+		"The interval (as a duration string, e.g. '10s', '1m') at which the controller checks for CRD availability when lazy-bind-reconcilers is enabled.",
+	)
 }
 
 // SetupLogger initializes the logger used in the service controller
@@ -379,6 +394,10 @@ func (cfg *Config) Validate(ctx context.Context, options ...Option) error {
 
 	if cfg.DeletionPolicy == "" {
 		cfg.DeletionPolicy = ackv1alpha1.DeletionPolicyDelete
+	}
+
+	if cfg.LazyBindReconcilers && cfg.LazyBindRetryInterval <= 0 {
+		return fmt.Errorf("invalid value for flag '%s': must be greater than 0 when lazy-bind-reconcilers is enabled", flagLazyBindRetryInterval)
 	}
 
 	if cfg.ReconcileDefaultResyncSeconds < 0 {

--- a/pkg/runtime/service_controller.go
+++ b/pkg/runtime/service_controller.go
@@ -16,19 +16,16 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	kubernetes "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	ctrlrt "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -100,53 +97,27 @@ func (c *serviceController) GetResourceManagerFactories() map[string]acktypes.AW
 	return c.rmFactories
 }
 
-// getResourceInstalled returns whether the given resource plural has been
-// installed into the cluster, and is accessible by the service controller.
-func (c *serviceController) getResourceInstalled(mgr ctrlrt.Manager, resourcePlural string) (bool, error) {
-	clusterConfig := mgr.GetConfig()
-	clientSet, err := kubernetes.NewForConfig(clusterConfig)
-	if err != nil {
+// getResourceInstalled returns whether the given GVR is installed in the
+// cluster by querying the manager's REST mapper.
+func (c *serviceController) getResourceInstalled(mgr ctrlrt.Manager, gvr schema.GroupVersionResource) (bool, error) {
+	if _, err := mgr.GetRESTMapper().KindFor(gvr); err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
 		return false, err
 	}
-
-	gv := schema.GroupVersion{
-		Group:   ackv1alpha1.GroupVersion.Group,
-		Version: ackv1alpha1.GroupVersion.Version,
-	}
-
-	// Ensure GV is supported
-	if err = discovery.ServerSupportsVersion(clientSet, gv); err != nil {
-		return false, nil
-	}
-
-	httpClient, err := rest.HTTPClientFor(clusterConfig)
-	if err != nil {
-		return false, err
-	}
-
-	restMapperClient, err := apiutil.NewDynamicRESTMapper(clusterConfig, httpClient)
-	if err != nil {
-		return false, err
-	}
-
-	gvr := schema.GroupVersionResource{
-		Group:    ackv1alpha1.GroupVersion.Group,
-		Version:  ackv1alpha1.GroupVersion.Version,
-		Resource: strings.ToLower(resourcePlural),
-	}
-
-	// Ensure individual kind is supported
-	if _, err := restMapperClient.KindFor(gvr); meta.IsNoMatchError(err) {
-		return false, nil
-	}
-
 	return true, nil
 }
 
 // GetFieldExportInstalled returns whether the FieldExport CRD has been
 // installed into the cluster, and is accessible by the service controller.
 func (c *serviceController) GetFieldExportInstalled(mgr ctrlrt.Manager) (bool, error) {
-	return c.getResourceInstalled(mgr, "fieldexports")
+	gvr := schema.GroupVersionResource{
+		Group:    ackv1alpha1.GroupVersion.Group,
+		Version:  ackv1alpha1.GroupVersion.Version,
+		Resource: "fieldexports",
+	}
+	return c.getResourceInstalled(mgr, gvr)
 }
 
 // WithLogger sets up the service controller with the supplied logger
@@ -195,7 +166,7 @@ func (c *serviceController) WithResourceManagerFactories(
 // reconcilers within the service controller with that manager. The adoption
 // reconciler will only be started if the types have been registered in the
 // cluster.
-func (c *serviceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg.Config) error {
+func (c *serviceController) BindControllerManager(ctx context.Context, stop context.CancelCauseFunc, mgr ctrlrt.Manager, cfg ackcfg.Config) error {
 	c.metaLock.Lock()
 	defer c.metaLock.Unlock()
 	c.cfg = cfg
@@ -298,23 +269,106 @@ func (c *serviceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg
 	}
 
 	for _, rmf := range filteredRMFs {
-		rec := NewReconciler(c, rmf, c.log, cfg, c.metrics, carmCache, irsCache)
-		if err := rec.BindControllerManager(mgr); err != nil {
-			return err
+		gvr := rmf.ResourceDescriptor().GroupVersionResource()
+		crdInstalled, err := c.getResourceInstalled(mgr, gvr)
+		if err != nil {
+			return fmt.Errorf("checking if CRD %s is installed: %w", gvr.Resource, err)
 		}
-		c.reconcilers = append(c.reconcilers, rec)
 
-		if cfg.EnableFieldExportReconciler && exporterInstalled {
-			rd := rmf.ResourceDescriptor()
-			feRec := NewFieldExportReconcilerForAWSResource(c, exporterLogger, cfg, c.metrics, carmCache, rd)
-			if err := feRec.BindControllerManager(mgr); err != nil {
+		if crdInstalled || !cfg.LazyBindReconcilers {
+			if err := c.bindReconciler(mgr, rmf, cfg, carmCache, irsCache, exporterInstalled, exporterLogger); err != nil {
 				return err
 			}
-			c.resourceFieldExportReconcilers = append(c.resourceFieldExportReconcilers, feRec)
+			continue
 		}
+
+		c.log.Info("CRD not yet installed, will bind reconciler in background once available", "resource", gvr.Resource)
+		go c.lazyBindReconciler(ctx, stop, mgr, rmf, cfg, carmCache, irsCache, exporterInstalled, exporterLogger)
 	}
 
 	return nil
+}
+
+// bindReconciler creates and binds a reconciler (and optionally a field export
+// reconciler) for the given resource manager factory.
+func (c *serviceController) bindReconciler(
+	mgr ctrlrt.Manager,
+	rmf acktypes.AWSResourceManagerFactory,
+	cfg ackcfg.Config,
+	carmCache ackrtcache.Caches,
+	irsCache *iamroleselector.Cache,
+	exporterInstalled bool,
+	exporterLogger logr.Logger,
+) error {
+	rec := NewReconciler(c, rmf, c.log, cfg, c.metrics, carmCache, irsCache)
+	if err := rec.BindControllerManager(mgr); err != nil {
+		return err
+	}
+	c.reconcilers = append(c.reconcilers, rec)
+
+	if cfg.EnableFieldExportReconciler && exporterInstalled {
+		rd := rmf.ResourceDescriptor()
+		feRec := NewFieldExportReconcilerForAWSResource(c, exporterLogger, cfg, c.metrics, carmCache, rd)
+		if err := feRec.BindControllerManager(mgr); err != nil {
+			return err
+		}
+		c.resourceFieldExportReconcilers = append(c.resourceFieldExportReconcilers, feRec)
+	}
+	return nil
+}
+
+// lazyBindReconciler polls until a CRD becomes available in the cluster, then
+// binds the reconciler. Transient errors (e.g. checking CRD availability) are
+// logged and retried since this runs in a background goroutine. A failure to
+// bind the reconciler once the CRD is available is a permanent, deterministic
+// error, so it triggers a graceful shutdown via stop() rather than leaving the
+// controller running with a silently missing reconciler.
+func (c *serviceController) lazyBindReconciler(
+	ctx context.Context,
+	stop context.CancelCauseFunc,
+	mgr ctrlrt.Manager,
+	rmf acktypes.AWSResourceManagerFactory,
+	cfg ackcfg.Config,
+	carmCache ackrtcache.Caches,
+	irsCache *iamroleselector.Cache,
+	exporterInstalled bool,
+	exporterLogger logr.Logger,
+) {
+	gvr := rmf.ResourceDescriptor().GroupVersionResource()
+	log := c.log.WithValues("resource", gvr.Resource, "group", gvr.Group)
+
+	ticker := time.NewTicker(cfg.LazyBindRetryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("context cancelled, stopping CRD watch")
+			return
+		case <-ticker.C:
+			installed, err := c.getResourceInstalled(mgr, gvr)
+			if err != nil {
+				log.Error(err, "error checking if CRD is installed, will retry")
+				continue
+			}
+			if !installed {
+				log.V(1).Info("CRD not yet installed, will retry")
+				continue
+			}
+		}
+
+		log.Info("CRD is now installed, binding reconciler")
+
+		c.metaLock.Lock()
+		err := c.bindReconciler(mgr, rmf, cfg, carmCache, irsCache, exporterInstalled, exporterLogger)
+		c.metaLock.Unlock()
+
+		if err != nil {
+			log.Error(err, "failed to bind reconciler after CRD became available, initiating graceful shutdown")
+			stop(fmt.Errorf("binding reconciler for %s after CRD became available: %w", gvr.Resource, err))
+		}
+		return
+	}
 }
 
 // GetMetadata returns the metadata associated with the service controller.

--- a/pkg/runtime/service_controller_test.go
+++ b/pkg/runtime/service_controller_test.go
@@ -16,6 +16,7 @@ package runtime
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -55,7 +56,7 @@ var (
 func init() {
 	groupVersion := schema.GroupVersion{Group: "bookstore.services.k8s.aws", Version: "v1alpha1"}
 	schemeBuilder := &k8sscheme.Builder{GroupVersion: groupVersion}
-	schemeBuilder.Register(&fakeBook{})
+	schemeBuilder.Register(&fakeBook{}, &fakeLazyBook{}, &fakeCancelBook{})
 
 	_ = schemeBuilder.AddToScheme(scheme)
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -102,7 +103,36 @@ func (b *fakeBook) DeepCopy() *fakeBook              { return nil }
 func (b *fakeBook) DeepCopyInto(*fakeBook)           {}
 func (b *fakeBook) DeepCopyObject() runtime.Object   { return nil }
 
-type fakeManager struct{}
+type fakeLazyBook struct{ fakeBook }
+
+func (b *fakeLazyBook) DeepCopyObject() runtime.Object { return nil }
+
+type fakeCancelBook struct{ fakeBook }
+
+func (b *fakeCancelBook) DeepCopyObject() runtime.Object { return nil }
+
+// fakeUnregisteredBook is intentionally NOT registered with the scheme so that
+// binding its reconciler fails deterministically inside controller-runtime's
+// builder, exercising the fatal-bind graceful-shutdown path.
+type fakeUnregisteredBook struct{ fakeBook }
+
+func (b *fakeUnregisteredBook) DeepCopyObject() runtime.Object { return nil }
+
+type fakeRESTMapper struct {
+	meta.RESTMapper
+	kindForFunc func(resource schema.GroupVersionResource) (schema.GroupVersionKind, error)
+}
+
+func (m *fakeRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	if m.kindForFunc != nil {
+		return m.kindForFunc(resource)
+	}
+	return schema.GroupVersionKind{}, &meta.NoResourceMatchError{PartialResource: resource}
+}
+
+type fakeManager struct {
+	restMapper meta.RESTMapper
+}
 
 func (m *fakeManager) GetLogger() logr.Logger {
 	return logr.New(log.NullLogSink{})
@@ -130,11 +160,16 @@ func (m *fakeManager) GetFieldIndexer() client.FieldIndexer                     
 func (m *fakeManager) GetCache() cache.Cache                                          { return nil }
 func (m *fakeManager) GetEventRecorderFor(name string) record.EventRecorder           { return nil }
 func (m *fakeManager) GetEventRecorder(name string) events.EventRecorder              { return nil }
-func (m *fakeManager) GetRESTMapper() meta.RESTMapper                                 { return nil }
-func (m *fakeManager) GetAPIReader() client.Reader                                    { return nil }
-func (m *fakeManager) GetWebhookServer() webhook.Server                               { return nil }
-func (m *fakeManager) AddMetricsServerExtraHandler(string, http.Handler) error        { return nil }
-func (m *fakeManager) GetConverterRegistry() conversion.Registry                      { return nil }
+func (m *fakeManager) GetRESTMapper() meta.RESTMapper {
+	if m.restMapper != nil {
+		return m.restMapper
+	}
+	return &fakeRESTMapper{}
+}
+func (m *fakeManager) GetAPIReader() client.Reader                              { return nil }
+func (m *fakeManager) GetWebhookServer() webhook.Server                         { return nil }
+func (m *fakeManager) AddMetricsServerExtraHandler(string, http.Handler) error  { return nil }
+func (m *fakeManager) GetConverterRegistry() conversion.Registry                { return nil }
 
 func TestServiceController(t *testing.T) {
 	require := require.New(t)
@@ -144,6 +179,13 @@ func TestServiceController(t *testing.T) {
 		schema.GroupVersionKind{
 			Group: "bookstore.services.k8s.aws",
 			Kind:  "fakeBook",
+		},
+	)
+	rd.On("GroupVersionResource").Return(
+		schema.GroupVersionResource{
+			Group:    "bookstore.services.k8s.aws",
+			Version:  "v1alpha1",
+			Resource: "fakebooks",
 		},
 	)
 	rd.On("EmptyRuntimeObject").Return(
@@ -184,7 +226,9 @@ func TestServiceController(t *testing.T) {
 		// Disable caches, by setting EnableCARM to false
 		EnableCARM: false,
 	}
-	err := sc.BindControllerManager(mgr, cfg)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	err := sc.BindControllerManager(ctx, cancel, mgr, cfg)
 	require.Nil(err)
 
 	recons = sc.GetReconcilers()
@@ -222,8 +266,224 @@ func TestBindControllerManagerStashesCfg(t *testing.T) {
 		EnableCARM:        false,
 		HTTPClientTimeout: 7 * time.Second,
 	}
-	err := sc.BindControllerManager(mgr, cfg)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	err := sc.BindControllerManager(ctx, cancel, mgr, cfg)
 	require.Nil(err)
 
 	require.Equal(7*time.Second, sc.cfg.HTTPClientTimeout)
+}
+
+func TestBindControllerManager_LazyBind_CRDNotInstalled(t *testing.T) {
+	require := require.New(t)
+
+	rd := &mocks.AWSResourceDescriptor{}
+	rd.On("GroupVersionKind").Return(
+		schema.GroupVersionKind{
+			Group: "bookstore.services.k8s.aws",
+			Kind:  "lazyFakeBook",
+		},
+	)
+	rd.On("GroupVersionResource").Return(
+		schema.GroupVersionResource{
+			Group:    "bookstore.services.k8s.aws",
+			Version:  "v1alpha1",
+			Resource: "lazyfakebooks",
+		},
+	)
+	rd.On("EmptyRuntimeObject").Return(&fakeLazyBook{})
+
+	rmf := &mocks.AWSResourceManagerFactory{}
+	rmf.On("ResourceDescriptor").Return(rd)
+	rmf.On("RequeueOnSuccessSeconds").Return(0)
+
+	var installCallCount int32
+	sc := &serviceController{
+		ServiceControllerMetadata: acktypes.ServiceControllerMetadata{
+			ServiceAlias:    "lazytest",
+			ServiceAPIGroup: "bookstore.services.k8s.aws",
+		},
+		rmFactories: map[string]acktypes.AWSResourceManagerFactory{
+			"lazyFakeBook.bookstore.services.k8s.aws": rmf,
+		},
+	}
+	sc.log = ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&ctrlrtzap.Options{
+		Development: true,
+		Level:       zapcore.InfoLevel,
+	}))
+
+	mapper := &fakeRESTMapper{
+		kindForFunc: func(_ schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+			atomic.AddInt32(&installCallCount, 1)
+			if atomic.LoadInt32(&installCallCount) >= 3 {
+				return schema.GroupVersionKind{Group: "bookstore.services.k8s.aws", Version: "v1alpha1", Kind: "lazyFakeBook"}, nil
+			}
+			return schema.GroupVersionKind{}, &meta.NoResourceMatchError{}
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	stopCtx, stop := context.WithCancelCause(ctx)
+	defer stop(nil)
+
+	mgr := &fakeManager{restMapper: mapper}
+	cfg := ackcfg.Config{
+		EnableCARM:            false,
+		LazyBindReconcilers:   true,
+		LazyBindRetryInterval: 100 * time.Millisecond,
+	}
+
+	err := sc.BindControllerManager(stopCtx, stop, mgr, cfg)
+	require.Nil(err)
+
+	// Reconciler should not be bound yet (it's in the background)
+	require.Empty(sc.GetReconcilers())
+
+	// Once the CRD becomes available, the background goroutine should bind the
+	// reconciler.
+	require.Eventually(func() bool {
+		return len(sc.GetReconcilers()) == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// A successful lazy bind must not trigger a shutdown.
+	require.NoError(context.Cause(stopCtx))
+}
+
+func TestBindControllerManager_LazyBind_ContextCancelled(t *testing.T) {
+	require := require.New(t)
+
+	rd := &mocks.AWSResourceDescriptor{}
+	rd.On("GroupVersionKind").Return(
+		schema.GroupVersionKind{
+			Group: "bookstore.services.k8s.aws",
+			Kind:  "cancelFakeBook",
+		},
+	)
+	rd.On("GroupVersionResource").Return(
+		schema.GroupVersionResource{
+			Group:    "bookstore.services.k8s.aws",
+			Version:  "v1alpha1",
+			Resource: "cancelfakebooks",
+		},
+	)
+	rd.On("EmptyRuntimeObject").Return(&fakeCancelBook{})
+
+	rmf := &mocks.AWSResourceManagerFactory{}
+	rmf.On("ResourceDescriptor").Return(rd)
+	rmf.On("RequeueOnSuccessSeconds").Return(0)
+
+	sc := &serviceController{
+		ServiceControllerMetadata: acktypes.ServiceControllerMetadata{
+			ServiceAlias:    "canceltest",
+			ServiceAPIGroup: "bookstore.services.k8s.aws",
+		},
+		rmFactories: map[string]acktypes.AWSResourceManagerFactory{
+			"cancelFakeBook.bookstore.services.k8s.aws": rmf,
+		},
+	}
+	sc.log = ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&ctrlrtzap.Options{
+		Development: true,
+		Level:       zapcore.InfoLevel,
+	}))
+
+	mapper := &fakeRESTMapper{
+		kindForFunc: func(_ schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+			return schema.GroupVersionKind{}, &meta.NoResourceMatchError{}
+		},
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	mgr := &fakeManager{restMapper: mapper}
+	cfg := ackcfg.Config{
+		EnableCARM:            false,
+		LazyBindReconcilers:   true,
+		LazyBindRetryInterval: 100 * time.Millisecond,
+	}
+
+	err := sc.BindControllerManager(ctx, cancel, mgr, cfg)
+	require.Nil(err)
+	require.Empty(sc.GetReconcilers())
+
+	// Cancel context — goroutine should exit gracefully
+	cancel(nil)
+
+	// Give the goroutine time to exit, then confirm no reconciler was bound
+	time.Sleep(100 * time.Millisecond)
+	require.Empty(sc.GetReconcilers())
+}
+
+func TestBindControllerManager_LazyBind_FatalBindTriggersShutdown(t *testing.T) {
+	require := require.New(t)
+
+	rd := &mocks.AWSResourceDescriptor{}
+	rd.On("GroupVersionKind").Return(
+		schema.GroupVersionKind{
+			Group: "bookstore.services.k8s.aws",
+			Kind:  "unregisteredFakeBook",
+		},
+	)
+	rd.On("GroupVersionResource").Return(
+		schema.GroupVersionResource{
+			Group:    "bookstore.services.k8s.aws",
+			Version:  "v1alpha1",
+			Resource: "unregisteredfakebooks",
+		},
+	)
+	// EmptyRuntimeObject returns a type that is not registered with the scheme,
+	// so binding the reconciler fails once the CRD becomes available.
+	rd.On("EmptyRuntimeObject").Return(&fakeUnregisteredBook{})
+
+	rmf := &mocks.AWSResourceManagerFactory{}
+	rmf.On("ResourceDescriptor").Return(rd)
+	rmf.On("RequeueOnSuccessSeconds").Return(0)
+
+	sc := &serviceController{
+		ServiceControllerMetadata: acktypes.ServiceControllerMetadata{
+			ServiceAlias:    "fataltest",
+			ServiceAPIGroup: "bookstore.services.k8s.aws",
+		},
+		rmFactories: map[string]acktypes.AWSResourceManagerFactory{
+			"unregisteredFakeBook.bookstore.services.k8s.aws": rmf,
+		},
+	}
+	sc.log = ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&ctrlrtzap.Options{
+		Development: true,
+		Level:       zapcore.InfoLevel,
+	}))
+
+	// The CRD is reported missing on the first check (routing the resource into
+	// the lazy-bind goroutine), then installed, so the goroutine attempts to
+	// bind and fails.
+	var installCallCount int32
+	mapper := &fakeRESTMapper{
+		kindForFunc: func(_ schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+			if atomic.AddInt32(&installCallCount, 1) == 1 {
+				return schema.GroupVersionKind{}, &meta.NoResourceMatchError{}
+			}
+			return schema.GroupVersionKind{Group: "bookstore.services.k8s.aws", Version: "v1alpha1", Kind: "unregisteredFakeBook"}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	mgr := &fakeManager{restMapper: mapper}
+	cfg := ackcfg.Config{
+		EnableCARM:            false,
+		LazyBindReconcilers:   true,
+		LazyBindRetryInterval: 50 * time.Millisecond,
+	}
+
+	err := sc.BindControllerManager(ctx, cancel, mgr, cfg)
+	require.Nil(err)
+
+	// The failed bind must trigger a graceful shutdown by cancelling the
+	// context with a non-nil cause.
+	require.Eventually(func() bool {
+		return context.Cause(ctx) != nil
+	}, 5*time.Second, 50*time.Millisecond)
+	require.ErrorContains(context.Cause(ctx), "unregisteredfakebooks")
+	require.Empty(sc.GetReconcilers())
 }

--- a/pkg/types/aws_resource_descriptor.go
+++ b/pkg/types/aws_resource_descriptor.go
@@ -29,6 +29,10 @@ type AWSResourceDescriptor interface {
 	// describes the API Group, Version and Kind of CRs described by the
 	// descriptor
 	GroupVersionKind() schema.GroupVersionKind
+	// GroupVersionResource returns a Kubernetes schema.GroupVersionResource struct that
+	// describes the API Group, Version and Resource of CRs described by the
+	// descriptor
+	GroupVersionResource() schema.GroupVersionResource
 	// EmptyRuntimeObject returns an empty object prototype that may be used in
 	// apimachinery and k8s client operations
 	EmptyRuntimeObject() rtclient.Object

--- a/pkg/types/service_controller.go
+++ b/pkg/types/service_controller.go
@@ -70,8 +70,13 @@ type ServiceController interface {
 
 	// BindControllerManager takes a `controller-runtime.Manager`, creates all
 	// the AWSResourceReconcilers needed for the service and binds all of the
-	// reconcilers within the service controller with that manager
+	// reconcilers within the service controller with that manager. The supplied
+	// context.CancelCauseFunc is invoked when a reconciler that was deferred via
+	// --lazy-bind-reconcilers fails to bind after its CRD becomes available,
+	// allowing the caller to trigger a graceful shutdown of the manager.
 	BindControllerManager(
+		context.Context,
+		context.CancelCauseFunc,
 		ctrlrt.Manager,
 		ackcfg.Config,
 	) error


### PR DESCRIPTION
Issue #, if available:

Description of changes:
When a reconciler is bound for a CRD that doesn't exist in the cluster,
controller-runtime's cache sync times out and crash-loops the pod. This
adds an opt-in flag that defers reconciler binding for missing CRDs
until they become available, allowing the controller to start serving
installed CRDs immediately.

When enabled, a background goroutine polls the discovery API every 10s
for each missing CRD, binding the reconciler once detected. The context
is respected for graceful shutdown, and bind failures trigger os.Exit(1)
since they indicate a permanent configuration error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
