### PR TITLE
Upgrade github.com/micahhausler/aws-iam-policy to latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/itchyny/gojq v0.12.6
 	github.com/jaypipes/envutil v1.0.0
-	github.com/micahhausler/aws-iam-policy v0.4.4
+	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.9

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/micahhausler/aws-iam-policy v0.4.4 h1:1aMhJ+0CkvUJ8HGN1chX+noXHs8uvGLkD7xIBeYd31c=
-github.com/micahhausler/aws-iam-policy v0.4.4/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 h1:J1D4vj3/AVzVoo1allyJJD3mh7J6bPWXVoQHOBQ+p5Y=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## Description

Upgrade `github.com/micahhausler/aws-iam-policy` from `v0.4.4` to `v0.4.5-0.20260511184658-411e29b8ffd2` to pick up order-independent comparison for `StringOrSlice` and `ConditionValue`.

https://github.com/micahhausler/aws-iam-policy/pull/3

## Why is this needed

Fixes: aws-controllers-k8s/community#2142

The previous version used order-sensitive `slices.Equal` for `Principal.Service`, `Action`, `Resource`, and condition value arrays. AWS IAM normalizes array ordering when storing policies, so semantically equivalent policies with different element ordering triggered false diffs in `IAMPolicyDocumentEqual`. This caused controllers (e.g., IAM) to call `UpdateAssumeRolePolicy` on every reconcile cycle indefinitely.

## How Has This Been Tested?

- All existing `TestIAMPolicyDocumentEqual` cases pass.
- Validated end-to-end via the IAM controller's `delta_test.go` which reproduces the exact issue scenario (reordered `Principal.Service` arrays and `Condition` keys).