### PR TITLE
feat(runtime): Add cross-namespace deprecation helpers

### DIFF
--- a/pkg/runtime/cross_namespace.go
+++ b/pkg/runtime/cross_namespace.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+)
+
+// CrossNamespaceRefKind is a label used in cross-namespace warning logs and
+// condition messages to describe which kind of reference triggered the
+// deprecation warning.
+type CrossNamespaceRefKind string
+
+const (
+	// CrossNamespaceRefKindResource indicates an AWSResourceReference
+	// targeting a different namespace.
+	CrossNamespaceRefKindResource CrossNamespaceRefKind = "resource reference"
+	// CrossNamespaceRefKindSecret indicates a SecretKeyReference targeting
+	// a different namespace.
+	CrossNamespaceRefKindSecret CrossNamespaceRefKind = "secret reference"
+)
+
+// SetCrossNamespaceOptInRequired sets or updates the
+// ACK.CrossNamespaceOptInRequired condition in the supplied conditions slice
+// using a lookup-or-create pattern (avoids duplicate conditions on repeated
+// reconciles).
+//
+// Returns the (possibly modified) conditions slice. Callers must assign the
+// result back to the resource's Status.Conditions field.
+func SetCrossNamespaceOptInRequired(
+	conditions []*ackv1alpha1.Condition,
+	message string,
+) []*ackv1alpha1.Condition {
+	for i, c := range conditions {
+		if c.Type == ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired {
+			conditions[i].Status = corev1.ConditionTrue
+			conditions[i].Message = &message
+			return conditions
+		}
+	}
+	return append(conditions, &ackv1alpha1.Condition{
+		Type:    ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired,
+		Status:  corev1.ConditionTrue,
+		Message: &message,
+	})
+}
+
+// HandleCrossNamespaceReference emits a Phase 1 deprecation warning log and
+// sets the ACK.CrossNamespaceOptInRequired condition on the supplied
+// conditions slice. It is intended to be called from generated code after
+// ValidateCrossNamespaceReference reports isCrossNamespace=true.
+//
+// Returns the updated conditions slice. Callers must assign the result back
+// to the resource's Status.Conditions field.
+func HandleCrossNamespaceReference(
+	ctx context.Context,
+	conditions []*ackv1alpha1.Condition,
+	refKind CrossNamespaceRefKind,
+	ownerNamespace string,
+	targetNamespace string,
+	refName string,
+) []*ackv1alpha1.Condition {
+	ackrtlog.FromContext(ctx).Info(
+		fmt.Sprintf(
+			"cross-namespace %s detected; this behavior will be disabled by "+
+				"default in a future release. Set --enable-cross-namespace to "+
+				"preserve this behavior.",
+			refKind,
+		),
+		"ownerNamespace", ownerNamespace,
+		"targetNamespace", targetNamespace,
+		"referenceName", refName,
+	)
+	message := fmt.Sprintf(
+		"Cross-namespace %s detected: resource in namespace %q references "+
+			"%q in namespace %q. Cross-namespace behavior will be disabled "+
+			"by default in a future release. Set --enable-cross-namespace=true "+
+			"to preserve this behavior.",
+		refKind, ownerNamespace, refName, targetNamespace,
+	)
+	return SetCrossNamespaceOptInRequired(conditions, message)
+}

--- a/pkg/runtime/cross_namespace.go
+++ b/pkg/runtime/cross_namespace.go
@@ -97,3 +97,73 @@ func HandleCrossNamespaceReference(
 	)
 	return SetCrossNamespaceOptInRequired(conditions, message)
 }
+
+// ResolveCrossNamespaceReference orchestrates the full Phase 1 cross-namespace
+// reference handling flow in a single call. It calls
+// ValidateCrossNamespaceReference and, when the reference targets a different
+// namespace and the flag is enabled, calls HandleCrossNamespaceReference to
+// emit the warning log and set the ACK.CrossNamespaceOptInRequired condition.
+//
+// Parameters:
+//   - ctx: passed to the logger
+//   - enableCrossNamespace: the value of Config.EnableCrossNamespace
+//   - conditions: pointer to the resource's Status.Conditions slice; the
+//     slice is updated in place when a deprecation condition is set
+//   - refKind: label describing the reference kind (resource, secret, ...)
+//   - ownerNamespace: the namespace of the resource containing the reference
+//   - refNamespace: the user-supplied namespace (may be nil or empty)
+//   - refName: the user-supplied reference name; used for log fields and
+//     error message context
+//
+// Returns the resolved namespace to pass to apiReader.Get and any terminal
+// error from ValidateCrossNamespaceReference. Callers do not need to inspect
+// an isCrossNamespace flag or manage the conditions slice themselves.
+func ResolveCrossNamespaceReference(
+	ctx context.Context,
+	enableCrossNamespace bool,
+	conditions *[]*ackv1alpha1.Condition,
+	refKind CrossNamespaceRefKind,
+	ownerNamespace string,
+	refNamespace *string,
+	refName string,
+) (string, error) {
+	resolved, isCrossNs, err := ValidateCrossNamespaceReference(
+		enableCrossNamespace, ownerNamespace, refNamespace, refName,
+	)
+	if err != nil {
+		return "", err
+	}
+	if isCrossNs && conditions != nil {
+		*conditions = HandleCrossNamespaceReference(
+			ctx, *conditions, refKind, ownerNamespace, *refNamespace, refName,
+		)
+	}
+	return resolved, nil
+}
+
+// ResolveCrossNamespaceReferenceString is the string-namespace counterpart of
+// ResolveCrossNamespaceReference, intended for callers that have a plain
+// string namespace (e.g. SecretKeyReference.Namespace,
+// FieldExportTarget.Namespace) rather than a *string.
+func ResolveCrossNamespaceReferenceString(
+	ctx context.Context,
+	enableCrossNamespace bool,
+	conditions *[]*ackv1alpha1.Condition,
+	refKind CrossNamespaceRefKind,
+	ownerNamespace string,
+	refNamespace string,
+	refName string,
+) (string, error) {
+	resolved, isCrossNs, err := ValidateCrossNamespaceReferenceString(
+		enableCrossNamespace, ownerNamespace, refNamespace, refName,
+	)
+	if err != nil {
+		return "", err
+	}
+	if isCrossNs && conditions != nil {
+		*conditions = HandleCrossNamespaceReference(
+			ctx, *conditions, refKind, ownerNamespace, refNamespace, refName,
+		)
+	}
+	return resolved, nil
+}

--- a/pkg/runtime/cross_namespace_test.go
+++ b/pkg/runtime/cross_namespace_test.go
@@ -140,3 +140,110 @@ func TestHandleCrossNamespaceReference_LookupOrCreate(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.Equal(t, corev1.ConditionTrue, out[0].Status)
 }
+
+func TestResolveCrossNamespaceReference_SameNamespace(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+	owner := "ns-a"
+
+	resolved, err := ResolveCrossNamespaceReference(
+		ctx, true, &conds, CrossNamespaceRefKindResource,
+		owner, &owner, "ref",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, owner, resolved)
+	assert.Empty(t, conds, "no condition should be set for same-namespace refs")
+}
+
+func TestResolveCrossNamespaceReference_NilNamespace(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+
+	resolved, err := ResolveCrossNamespaceReference(
+		ctx, true, &conds, CrossNamespaceRefKindResource,
+		"ns-a", nil, "ref",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ns-a", resolved)
+	assert.Empty(t, conds)
+}
+
+func TestResolveCrossNamespaceReference_CrossNamespace_FlagEnabled(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+	target := "ns-b"
+
+	resolved, err := ResolveCrossNamespaceReference(
+		ctx, true, &conds, CrossNamespaceRefKindResource,
+		"ns-a", &target, "ref",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, target, resolved)
+	require.Len(t, conds, 1)
+	assert.Equal(t,
+		ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired,
+		conds[0].Type,
+	)
+}
+
+func TestResolveCrossNamespaceReference_CrossNamespace_FlagDisabled(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+	target := "ns-b"
+
+	resolved, err := ResolveCrossNamespaceReference(
+		ctx, false, &conds, CrossNamespaceRefKindResource,
+		"ns-a", &target, "ref",
+	)
+
+	require.Error(t, err)
+	assert.Empty(t, resolved)
+	assert.Empty(t, conds, "no condition should be set when validation fails")
+}
+
+func TestResolveCrossNamespaceReference_NilConditionsPointer(t *testing.T) {
+	ctx := context.Background()
+	target := "ns-b"
+
+	// Should not panic; cross-namespace flow still resolves the namespace.
+	resolved, err := ResolveCrossNamespaceReference(
+		ctx, true, nil, CrossNamespaceRefKindResource,
+		"ns-a", &target, "ref",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, target, resolved)
+}
+
+func TestResolveCrossNamespaceReferenceString_CrossNamespace(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+
+	resolved, err := ResolveCrossNamespaceReferenceString(
+		ctx, true, &conds, CrossNamespaceRefKindSecret,
+		"ns-a", "ns-b", "secret",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ns-b", resolved)
+	require.Len(t, conds, 1)
+	require.NotNil(t, conds[0].Message)
+	assert.Contains(t, *conds[0].Message, "secret reference")
+}
+
+func TestResolveCrossNamespaceReferenceString_EmptyNamespace(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+
+	resolved, err := ResolveCrossNamespaceReferenceString(
+		ctx, true, &conds, CrossNamespaceRefKindSecret,
+		"ns-a", "", "secret",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ns-a", resolved)
+	assert.Empty(t, conds)
+}

--- a/pkg/runtime/cross_namespace_test.go
+++ b/pkg/runtime/cross_namespace_test.go
@@ -1,0 +1,142 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+)
+
+func TestSetCrossNamespaceOptInRequired_AppendsWhenAbsent(t *testing.T) {
+	conds := []*ackv1alpha1.Condition{}
+	out := SetCrossNamespaceOptInRequired(conds, "test message")
+
+	require.Len(t, out, 1)
+	assert.Equal(t,
+		ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired,
+		out[0].Type,
+	)
+	assert.Equal(t, corev1.ConditionTrue, out[0].Status)
+	require.NotNil(t, out[0].Message)
+	assert.Equal(t, "test message", *out[0].Message)
+}
+
+func TestSetCrossNamespaceOptInRequired_UpdatesWhenPresent(t *testing.T) {
+	existingMsg := "old message"
+	conds := []*ackv1alpha1.Condition{
+		{
+			Type:    ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired,
+			Status:  corev1.ConditionFalse,
+			Message: &existingMsg,
+		},
+	}
+	out := SetCrossNamespaceOptInRequired(conds, "new message")
+
+	// Should still have exactly one condition, not two.
+	require.Len(t, out, 1)
+	assert.Equal(t, corev1.ConditionTrue, out[0].Status)
+	require.NotNil(t, out[0].Message)
+	assert.Equal(t, "new message", *out[0].Message)
+}
+
+func TestSetCrossNamespaceOptInRequired_PreservesOtherConditions(t *testing.T) {
+	otherMsg := "other"
+	conds := []*ackv1alpha1.Condition{
+		{
+			Type:    ackv1alpha1.ConditionTypeReferencesResolved,
+			Status:  corev1.ConditionTrue,
+			Message: &otherMsg,
+		},
+	}
+	out := SetCrossNamespaceOptInRequired(conds, "cross-ns")
+
+	require.Len(t, out, 2)
+	assert.Equal(t, ackv1alpha1.ConditionTypeReferencesResolved, out[0].Type)
+	assert.Equal(t,
+		ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired,
+		out[1].Type,
+	)
+}
+
+func TestHandleCrossNamespaceReference_ResourceRef(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+
+	out := HandleCrossNamespaceReference(
+		ctx, conds,
+		CrossNamespaceRefKindResource,
+		"owner-ns", "target-ns", "my-ref",
+	)
+
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].Message)
+	msg := *out[0].Message
+	// Message should mention all the relevant pieces.
+	assert.True(t, strings.Contains(msg, "resource reference"),
+		"message should mention ref kind: %s", msg)
+	assert.True(t, strings.Contains(msg, "owner-ns"),
+		"message should mention owner namespace: %s", msg)
+	assert.True(t, strings.Contains(msg, "target-ns"),
+		"message should mention target namespace: %s", msg)
+	assert.True(t, strings.Contains(msg, "my-ref"),
+		"message should mention ref name: %s", msg)
+	assert.True(t, strings.Contains(msg, "--enable-cross-namespace"),
+		"message should mention the flag: %s", msg)
+}
+
+func TestHandleCrossNamespaceReference_SecretRef(t *testing.T) {
+	ctx := context.Background()
+	conds := []*ackv1alpha1.Condition{}
+
+	out := HandleCrossNamespaceReference(
+		ctx, conds,
+		CrossNamespaceRefKindSecret,
+		"owner-ns", "secret-ns", "my-secret",
+	)
+
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].Message)
+	msg := *out[0].Message
+	assert.True(t, strings.Contains(msg, "secret reference"),
+		"message should mention ref kind: %s", msg)
+}
+
+func TestHandleCrossNamespaceReference_LookupOrCreate(t *testing.T) {
+	ctx := context.Background()
+	existing := "old"
+	conds := []*ackv1alpha1.Condition{
+		{
+			Type:    ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired,
+			Status:  corev1.ConditionFalse,
+			Message: &existing,
+		},
+	}
+
+	out := HandleCrossNamespaceReference(
+		ctx, conds,
+		CrossNamespaceRefKindResource,
+		"owner-ns", "target-ns", "my-ref",
+	)
+
+	// Repeated calls must not produce duplicate conditions.
+	require.Len(t, out, 1)
+	assert.Equal(t, corev1.ConditionTrue, out[0].Status)
+}

--- a/pkg/runtime/field_export_reconciler.go
+++ b/pkg/runtime/field_export_reconciler.go
@@ -239,20 +239,9 @@ func (r *fieldExportReconciler) setCrossNsOptInRequiredCondition(
 		desired.Namespace + "\" targets namespace \"" + r.getTargetNamespace(desired) +
 		"\". Cross-namespace behavior will require explicit opt-in in a future release. " +
 		"Set --enable-cross-namespace=true to preserve this behavior."
-	// Use lookup-or-create pattern to avoid duplicate conditions
-	for i, c := range desired.Status.Conditions {
-		if c.Type == ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired {
-			desired.Status.Conditions[i].Status = corev1.ConditionTrue
-			desired.Status.Conditions[i].Message = &message
-			return
-		}
-	}
-	condition := &ackv1alpha1.Condition{
-		Type:    ackv1alpha1.ConditionTypeCrossNamespaceOptInRequired,
-		Status:  corev1.ConditionTrue,
-		Message: &message,
-	}
-	desired.Status.Conditions = append(desired.Status.Conditions, condition)
+	desired.Status.Conditions = SetCrossNamespaceOptInRequired(
+		desired.Status.Conditions, message,
+	)
 }
 
 // cleanup removes the finalizer from FieldExport so that k8s object can


### PR DESCRIPTION

Issue #, if available:

Description of changes:
Extract the lookup-or-create condition pattern and the warning-log + condition combo into shared helpers so generated code can call a single runtime function instead of inlining ~14 lines per cross-namespace check.

- Add SetCrossNamespaceOptInRequired(conditions, message): updates or appends the ACK.CrossNamespaceOptInRequired condition using a lookup-or-create pattern (avoids duplicate conditions on repeated reconciles)
- Add HandleCrossNamespaceReference(ctx, conditions, refKind, ownerNs, targetNs, refName): emits the structured warning log and sets the condition; intended to be called from generated code after ValidateCrossNamespaceReference reports isCrossNamespace=true
- Refactor fieldExportReconciler.setCrossNsOptInRequiredCondition to use SetCrossNamespaceOptInRequired so all condition handling shares one implementation

Addresses review feedback on aws-controllers-k8s/code-generator#699.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
