### PR TITLE
fix: Retain AWS API errors in status conditions when create or update fails

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -781,6 +781,9 @@ func (r *resourceReconciler) createResource(
 	latest, err = rm.Create(ctx, desired)
 	rlog.Exit("rm.Create", err)
 	if err != nil {
+		if latest == nil {
+			latest = desired.DeepCopy()
+		}
 		// Here we're deciding to set a resource as unmanaged
 		// if the error is an AWS API Error. This will ensure
 		// that we're only managing (put finalizer) the resources
@@ -910,6 +913,9 @@ func (r *resourceReconciler) updateResource(
 		updated, err = rm.Update(ctx, desired, latest, delta)
 		rlog.Exit("rm.Update", err, "latest", latest)
 		if err != nil {
+			if updated == nil {
+				updated = latest
+			}
 			return updated, err
 		}
 		// Ensure that we are patching any changes to the annotations/metadata and


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#2864

## What is this PR?
This PR fixes a bug where `ACK.ResourceSynced` conditions failed to update with AWS API error messages when a resource creation or update failed.

## Why?
When `rm.Create` or `rm.Update` failed, they returned a `nil` resource object along with the AWS API error. Because the resource object returned was `nil`, the runtime reconciler effectively erased the `latest` observed state in K8s memory. The `ensureConditions` defer block (which attaches status conditions like terminal errors or AWS API failures) would immediately exit because the provided `latest` resource was `nil`. Consequently, the API error was never patched to the Kubernetes custom resource status.

By ensuring that `latest` and `updated` variables fallback to retaining their non-nil states (`desired` in case of create, `latest` in case of update) before returning the error, the `ensureConditions` logic will successfully attach the API error to the condition and propagate it to the Kubernetes API.

## Testing Evidence
Ran existing unit test suite in `pkg/runtime/...` via `go test` which successfully passed. The fix ensures `latest` object is not dropped.
