### PR TITLE
fix(runtime): do not unmanage resource if created in AWS

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -781,14 +781,20 @@ func (r *resourceReconciler) createResource(
 	latest, err = rm.Create(ctx, desired)
 	rlog.Exit("rm.Create", err)
 	if err != nil {
+		createdInAWS := latest != nil
+		if latest == nil {
+			latest = desired.DeepCopy()
+		}
 		// Here we're deciding to set a resource as unmanaged
 		// if the error is an AWS API Error. This will ensure
 		// that we're only managing (put finalizer) the resources
 		// that actually exist in AWS.
-		if _, ok := ackerr.AWSError(err); ok {
-			mErr := r.setResourceUnmanaged(ctx, rm, desired)
-			if mErr != nil {
-				return latest, err
+		if !createdInAWS {
+			if _, ok := ackerr.AWSError(err); ok {
+				mErr := r.setResourceUnmanaged(ctx, rm, desired)
+				if mErr != nil {
+					return latest, err
+				}
 			}
 		}
 		return latest, err

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -245,7 +245,11 @@ func TestReconcilerCreate_UnmanageResourceOnAWSErrors(t *testing.T) {
 	arn := ackv1alpha1.AWSResourceName("mybook-arn")
 
 	desired, desiredRTObj, _ := resourceMocks()
-	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
+	desired.On(
+		"ReplaceConditions",
+		mock.AnythingOfType("[]*v1alpha1.Condition"),
+	).Return()
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -269,9 +273,9 @@ func TestReconcilerCreate_UnmanageResourceOnAWSErrors(t *testing.T) {
 		latest, ackerr.NotFound,
 	).Once()
 	rm.On("Create", ctx, desired).Return(
-		latest, awsError{},
+		nil, awsError{},
 	)
-	rm.On("IsSynced", ctx, latest).Return(false, nil)
+	rm.On("IsSynced", ctx, desired).Return(false, nil)
 	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
 	rd.On("IsManaged", desired).Return(false).Twice()
 	rd.On("IsManaged", desired).Return(true)


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#2849

This PR ensures that resources are not unmanaged (by removing the finalizer) if the primary resource was successfully created in AWS (indicated by "latest != nil").

Previously, any AWS API error returned from the Create flow would unmanage the resource. This is problematic for resources with post-create hooks (like SecurityGroup egress rule sync or WebACL logging configuration). If the hook fails, the primary resource is left orphaned in AWS because the finalizer is removed, and on subsequent reconciliations the controller will either try to recreate it or fail because the name already exists.

This PR fixes this by checking if "latest != nil". If it is not nil, it means the controller explicitly returned the created resource despite a subsequent hook error, so we should keep managing it.