### PR TITLE
feat: Preserve nested references when patching spec

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -1061,6 +1061,17 @@ func (r *resourceReconciler) patchResourceMetadataAndSpec(
 		exit(err)
 	}()
 
+	// Restore reference (*Ref) values that may have been dropped when latest
+	// was rebuilt from an API response. Nested *Ref fields live inside structs
+	// that get reconstructed from the response (which carries only the concrete
+	// resolved values), so they are otherwise lost. This is implemented as an
+	// optional interface so controllers generated before this method existed
+	// continue to compile and run; they simply do not get the preservation
+	// until regenerated.
+	if p, ok := rm.(acktypes.ReferenceValuesPreserver); ok {
+		latest = p.PreserveReferenceValues(desired, latest)
+	}
+
 	// Remove resolved references from the objects before patching
 	desiredCleaned := rm.ClearResolvedReferences(desired)
 	latestCleaned := rm.ClearResolvedReferences(latest)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -1061,13 +1061,8 @@ func (r *resourceReconciler) patchResourceMetadataAndSpec(
 		exit(err)
 	}()
 
-	// Restore reference (*Ref) values that may have been dropped when latest
-	// was rebuilt from an API response. Nested *Ref fields live inside structs
-	// that get reconstructed from the response (which carries only the concrete
-	// resolved values), so they are otherwise lost. This is implemented as an
-	// optional interface so controllers generated before this method existed
-	// continue to compile and run; they simply do not get the preservation
-	// until regenerated.
+	// Restore nested *Ref values that were dropped when latest was rebuilt from
+	// an API response. Optional, so older generated controllers are unaffected.
 	if p, ok := rm.(acktypes.ReferenceValuesPreserver); ok {
 		latest = p.PreserveReferenceValues(desired, latest)
 	}

--- a/pkg/types/reference_manager.go
+++ b/pkg/types/reference_manager.go
@@ -36,3 +36,20 @@ type ReferenceManager interface {
 	// values.
 	ClearResolvedReferences(AWSResource) AWSResource
 }
+
+// ReferenceValuesPreserver is optionally implemented by resource managers that
+// can preserve nested reference (*Ref) values when a resource is rebuilt from
+// an API response.
+//
+// It is intentionally kept separate from ReferenceManager (rather than added
+// to it) so that controllers generated before this method existed continue to
+// satisfy the AWSResourceManager interface. The reconciler invokes it via a
+// type assertion and skips it when the resource manager does not implement it.
+type ReferenceValuesPreserver interface {
+	// PreserveReferenceValues copies nested reference (*Ref) values from the
+	// `from` resource into a copy of the `to` resource and returns that copy.
+	// `to` is typically a resource rebuilt from an API response, whose nested
+	// *Ref values were dropped because the response carries only the concrete
+	// (resolved) values.
+	PreserveReferenceValues(from AWSResource, to AWSResource) AWSResource
+}

--- a/pkg/types/reference_manager.go
+++ b/pkg/types/reference_manager.go
@@ -37,19 +37,12 @@ type ReferenceManager interface {
 	ClearResolvedReferences(AWSResource) AWSResource
 }
 
-// ReferenceValuesPreserver is optionally implemented by resource managers that
-// can preserve nested reference (*Ref) values when a resource is rebuilt from
-// an API response.
-//
-// It is intentionally kept separate from ReferenceManager (rather than added
-// to it) so that controllers generated before this method existed continue to
-// satisfy the AWSResourceManager interface. The reconciler invokes it via a
-// type assertion and skips it when the resource manager does not implement it.
+// ReferenceValuesPreserver is an optional interface, kept separate from
+// ReferenceManager so older generated controllers still satisfy
+// AWSResourceManager. The reconciler invokes it via a type assertion.
 type ReferenceValuesPreserver interface {
-	// PreserveReferenceValues copies nested reference (*Ref) values from the
-	// `from` resource into a copy of the `to` resource and returns that copy.
-	// `to` is typically a resource rebuilt from an API response, whose nested
-	// *Ref values were dropped because the response carries only the concrete
-	// (resolved) values.
+	// PreserveReferenceValues copies nested *Ref values from `from` into a copy
+	// of `to` and returns that copy. `to` is typically rebuilt from an API
+	// response, which carries only the concrete values.
 	PreserveReferenceValues(from AWSResource, to AWSResource) AWSResource
 }


### PR DESCRIPTION
## Description

Nested cross-resource references (`*Ref` fields inside struct fields) are dropped from a resource's `.spec` after it is rebuilt from an AWS API response. The response carries only the concrete resolved values and has no concept of the `*Ref` fields, so reconstructing the parent struct discards them. Top-level references are unaffected because the `*Ref` field is a sibling that is never rebuilt.

### Change

`patchResourceMetadataAndSpec` is the single chokepoint every reconcile path funnels through (create, update, read, adoption, late-init). Before computing the spec patch, it now copies the nested `*Ref` values from `desired` into `latest`:

```go
if p, ok := rm.(acktypes.ReferenceValuesPreserver); ok {
    latest = p.PreserveReferenceValues(desired, latest)
}
```

Placing this in the runtime — rather than in the generated `sdk*` output-setting code — means it also covers resources with **fully custom `sdkCreate`/`sdkUpdate`/`sdkFind` implementations**, which return early and bypass the generated output mapping entirely.

### Non-breaking rollout

`PreserveReferenceValues` is exposed through a new, separate `ReferenceValuesPreserver` interface rather than being added to `ReferenceManager`. The reconciler invokes it via a type assertion, so:

- Controllers generated before this method existed still satisfy `AWSResourceManager` and compile unchanged.
- They opt in to the behavior simply by regenerating against the updated code-generator.

The generated method is produced by the companion code-generator change (aws-controllers-k8s/code-generator#718).

### Testing

- `go build ./...` and `go test ./pkg/runtime/...` pass.
- Existing reconciler tests are unaffected (the mock resource manager does not implement the optional interface, so the assertion is skipped).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
