### PR TITLE
fix: give Update a copy of desired carrying the observed status

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -948,6 +948,24 @@ func (r *resourceReconciler) delayedReadOneAfterCreate(
 	return observed, nil
 }
 
+// setStatusWithoutConditions copies src's status onto dst, keeping dst's own
+// conditions.
+//
+// Status holds both service-reported state and ACK's conditions, and SetStatus
+// replaces the whole struct, so it cannot adopt observed state without also
+// adopting src's conditions. Neither side's conditions belong in the result:
+// adopting src's suppresses recomputation, since resetConditions clears
+// conditions each reconcile so ensureConditions can rebuild them and
+// ensureConditions only runs while Synced is nil; dropping dst's loses
+// conditions set after resetConditions, notably ACK.ReferencesResolved.
+//
+// src is deep-copied so the two do not share status pointers.
+func setStatusWithoutConditions(dst, src acktypes.AWSResource) {
+	conditions := dst.Conditions()
+	dst.SetStatus(src.DeepCopy())
+	dst.ReplaceConditions(conditions)
+}
+
 // updateResource calls one or more AWS APIs to modify the backend AWS resource
 // and patches the CR's Metadata and Spec back to the Kubernetes API.
 //
@@ -987,18 +1005,16 @@ func (r *resourceReconciler) updateResource(
 	// paths are known syntactically valid; no need to re-check.
 	// Hand Update a copy, never the stored `desired` itself. ACK permits a
 	// resource manager's Update to return the object it was given, and several
-	// hand-written customUpdate implementations do exactly that. If that object
-	// were `desired`, it would also be the base of the status merge patch in
-	// patchResourceStatus -- base and target would be the same object, the
-	// computed patch would be empty, and any status the manager just set
-	// (conditions, observed state) would be silently dropped.
+	// hand-written customUpdate implementations do. Were that object `desired`,
+	// it would also be the base of the status merge patch in
+	// patchResourceStatus: base and target identical, patch empty, and any
+	// status the manager just set silently dropped.
 	reconcileDesired := desired.DeepCopy()
 	if r.cfg.FeatureGates.IsEnabled(featuregate.IgnoreFieldDrift) &&
 		HasIgnoreFieldDrift(desired) {
-		// Transform the copy, not `desired`. applyIgnoredFields returns its
-		// first argument unchanged on several paths, so feeding it the copy
-		// keeps the "never hand Update the stored desired" invariant true here
-		// regardless of which path it takes, and avoids a second deep copy.
+		// Transform the copy, not `desired`: applyIgnoredFields returns its first
+		// argument unchanged on several paths, so passing the copy keeps the
+		// invariant above regardless of path, and avoids a second deep copy.
 		merged, mergeErr := applyIgnoredFields(reconcileDesired, latest, r.cfg.FeatureGates)
 		if mergeErr != nil {
 			rlog.Info(
@@ -1011,29 +1027,11 @@ func (r *resourceReconciler) updateResource(
 			r.logIgnoredFieldDrift(ctx, desired, latest)
 		}
 	}
-	// Apply the observed status to whichever copy we ended up with: `desired`
-	// carries the status last persisted to etcd, `latest` carries what the
-	// service reports now, and an Update should reason about observed state.
-	//
-	// Deliberately after the branch above rather than beside the DeepCopy, so
-	// this holds whatever applyIgnoredFields returns. Placing it earlier happens
-	// to work today only because that function derives from its first argument
-	// and round-trips the whole object, preserving status -- neither of which it
-	// promises.
-	//
-	// Conditions then have to be cleared. They live in Status, so copying the
-	// observed status also copies whatever conditions `latest` happens to carry,
-	// and a ReadOne hook may set one -- ec2-controller's VPCEndpoint marks
-	// Synced=False while the endpoint is pending, for instance. Carrying that
-	// forward defeats the condition lifecycle: resetConditions clears conditions
-	// at the top of Sync precisely so ensureConditions recomputes them, and
-	// ensureConditions only recomputes while Synced is nil. Clearing here is the
-	// same reset applied to the copy, and leaves the copy meaning what
-	// reconciling against observed state should mean: observed service state,
-	// freshly computed conditions. Conditions a manager sets during Update are
-	// unaffected, since those happen after this point.
-	reconcileDesired.SetStatus(latest)
-	ackcondition.Clear(reconcileDesired)
+	// Reconcile against observed state: `desired` carries the status last
+	// persisted to etcd, `latest` what the service reports now. After the branch
+	// above so it holds whatever applyIgnoredFields returned; that function
+	// preserves status today but does not promise to.
+	setStatusWithoutConditions(reconcileDesired, latest)
 
 	// Check to see if the latest observed state already matches the
 	// desired state and if not, update the resource

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -1011,11 +1011,15 @@ func (r *resourceReconciler) updateResource(
 			r.logIgnoredFieldDrift(ctx, desired, latest)
 		}
 	}
-	// Carry the observed status onto the copy. `desired` holds the status last
-	// persisted to etcd; `latest` holds what the service reports now. An Update
-	// must reason about observed state, so the copy is given the observed
-	// status. This must run after the ignore-field-drift branch above, which
-	// may replace the copy.
+	// Apply the observed status to whichever copy we ended up with: `desired`
+	// carries the status last persisted to etcd, `latest` carries what the
+	// service reports now, and an Update should reason about observed state.
+	//
+	// Deliberately after the branch above rather than beside the DeepCopy, so
+	// this holds whatever applyIgnoredFields returns. Placing it earlier happens
+	// to work today only because that function derives from its first argument
+	// and round-trips the whole object, preserving status -- neither of which it
+	// promises.
 	reconcileDesired.SetStatus(latest)
 
 	// Check to see if the latest observed state already matches the

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -985,7 +985,14 @@ func (r *resourceReconciler) updateResource(
 	// A malformed ignore-field-drift annotation is rejected as a terminal error
 	// earlier in Sync (before create/update), so by the time we reach here the
 	// paths are known syntactically valid; no need to re-check.
-	reconcileDesired := desired
+	// Hand Update a copy, never the stored `desired` itself. ACK permits a
+	// resource manager's Update to return the object it was given, and several
+	// hand-written customUpdate implementations do exactly that. If that object
+	// were `desired`, it would also be the base of the status merge patch in
+	// patchResourceStatus -- base and target would be the same object, the
+	// computed patch would be empty, and any status the manager just set
+	// (conditions, observed state) would be silently dropped.
+	reconcileDesired := desired.DeepCopy()
 	if r.cfg.FeatureGates.IsEnabled(featuregate.IgnoreFieldDrift) &&
 		HasIgnoreFieldDrift(desired) {
 		merged, mergeErr := applyIgnoredFields(desired, latest, r.cfg.FeatureGates)
@@ -1000,6 +1007,12 @@ func (r *resourceReconciler) updateResource(
 			r.logIgnoredFieldDrift(ctx, desired, latest)
 		}
 	}
+	// Carry the observed status onto the copy. `desired` holds the status last
+	// persisted to etcd; `latest` holds what the service reports now. An Update
+	// must reason about observed state, so the copy is given the observed
+	// status. This must run after the ignore-field-drift branch above, which
+	// replaces the copy with one derived from `desired`.
+	reconcileDesired.SetStatus(latest)
 
 	// Check to see if the latest observed state already matches the
 	// desired state and if not, update the resource

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -1020,7 +1020,20 @@ func (r *resourceReconciler) updateResource(
 	// to work today only because that function derives from its first argument
 	// and round-trips the whole object, preserving status -- neither of which it
 	// promises.
+	//
+	// Conditions then have to be cleared. They live in Status, so copying the
+	// observed status also copies whatever conditions `latest` happens to carry,
+	// and a ReadOne hook may set one -- ec2-controller's VPCEndpoint marks
+	// Synced=False while the endpoint is pending, for instance. Carrying that
+	// forward defeats the condition lifecycle: resetConditions clears conditions
+	// at the top of Sync precisely so ensureConditions recomputes them, and
+	// ensureConditions only recomputes while Synced is nil. Clearing here is the
+	// same reset applied to the copy, and leaves the copy meaning what
+	// reconciling against observed state should mean: observed service state,
+	// freshly computed conditions. Conditions a manager sets during Update are
+	// unaffected, since those happen after this point.
 	reconcileDesired.SetStatus(latest)
+	ackcondition.Clear(reconcileDesired)
 
 	// Check to see if the latest observed state already matches the
 	// desired state and if not, update the resource

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -995,7 +995,11 @@ func (r *resourceReconciler) updateResource(
 	reconcileDesired := desired.DeepCopy()
 	if r.cfg.FeatureGates.IsEnabled(featuregate.IgnoreFieldDrift) &&
 		HasIgnoreFieldDrift(desired) {
-		merged, mergeErr := applyIgnoredFields(desired, latest, r.cfg.FeatureGates)
+		// Transform the copy, not `desired`. applyIgnoredFields returns its
+		// first argument unchanged on several paths, so feeding it the copy
+		// keeps the "never hand Update the stored desired" invariant true here
+		// regardless of which path it takes, and avoids a second deep copy.
+		merged, mergeErr := applyIgnoredFields(reconcileDesired, latest, r.cfg.FeatureGates)
 		if mergeErr != nil {
 			rlog.Info(
 				"failed to apply ignore-field-drift annotation; "+
@@ -1011,7 +1015,7 @@ func (r *resourceReconciler) updateResource(
 	// persisted to etcd; `latest` holds what the service reports now. An Update
 	// must reason about observed state, so the copy is given the observed
 	// status. This must run after the ignore-field-drift branch above, which
-	// replaces the copy with one derived from `desired`.
+	// may replace the copy.
 	reconcileDesired.SetStatus(latest)
 
 	// Check to see if the latest observed state already matches the

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -2731,8 +2731,9 @@ func TestReconcilerUpdate_PassesCopyOfDesiredToUpdate(t *testing.T) {
 	desired := resourceMockReturningCopy(desiredCopy)
 	latest, _, _ := resourceMocks()
 
-	// The copy is also given the observed status before Update sees it.
+	// The copy is given the observed status, then had its conditions cleared.
 	desiredCopy.On("SetStatus", latest).Return()
+	desiredCopy.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
 
 	rm := &ackmocks.AWSResourceManager{}
 	// Model a customUpdate that hands back the resource it was given.
@@ -2762,4 +2763,8 @@ func TestReconcilerUpdate_PassesCopyOfDesiredToUpdate(t *testing.T) {
 	require.NotSame(acktypes.AWSResource(desired), updated)
 	// And the copy carries the observed status, not the last-persisted one.
 	desiredCopy.AssertCalled(t, "SetStatus", latest)
+	// Conditions come along with the observed status, so they are cleared to
+	// keep the runtime's condition lifecycle intact: a condition set by a
+	// ReadOne hook on `latest` must not suppress ensureConditions.
+	desiredCopy.AssertCalled(t, "ReplaceConditions", []*ackv1alpha1.Condition{})
 }

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -183,6 +183,7 @@ func TestReconcilerCreate_BackoffRetries(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -694,6 +695,7 @@ func TestReconcilerCreate_UnManagedResource_CheckReferencesResolveOnce(t *testin
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -782,6 +784,7 @@ func TestReconcilerCreate_ManagedResource_CheckReferencesResolveOnce(t *testing.
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -870,6 +873,7 @@ func TestReconcilerUpdate(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -959,6 +963,7 @@ func TestReconcilerUpdate_ResourceNotSynced(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1048,6 +1053,7 @@ func TestReconcilerUpdate_NoDelta_ResourceNotSynced(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1132,6 +1138,7 @@ func TestReconcilerUpdate_NoDelta_ResourceSynced(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1217,6 +1224,7 @@ func TestReconcilerUpdate_IsSyncedError(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1311,6 +1319,7 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInMetadata(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1382,6 +1391,7 @@ func TestReconcilerUpdate_PatchMetadataAndSpec_DiffInSpec(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1532,6 +1542,7 @@ func TestReconcilerUpdate_ErrorInLateInitialization(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1622,6 +1633,7 @@ func TestReconcilerUpdate_ResourceNotManaged(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -1820,6 +1832,7 @@ func TestReconcilerUpdate_EnsureControllerTagsError(t *testing.T) {
 
 	desired, _, _ := resourceMocks()
 	desired.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	desired.On("Conditions").Return([]*ackv1alpha1.Condition{})
 
 	ids := &ackmocks.AWSResourceIdentifiers{}
 	ids.On("ARN").Return(&arn)
@@ -2731,9 +2744,13 @@ func TestReconcilerUpdate_PassesCopyOfDesiredToUpdate(t *testing.T) {
 	desired := resourceMockReturningCopy(desiredCopy)
 	latest, _, _ := resourceMocks()
 
-	// The copy is given the observed status, then had its conditions cleared.
-	desiredCopy.On("SetStatus", latest).Return()
-	desiredCopy.On("ReplaceConditions", []*ackv1alpha1.Condition{}).Return()
+	// The copy adopts the observed status but keeps its own conditions. Stand in
+	// for a condition the reconcile already set, e.g. ACK.ReferencesResolved.
+	inFlight := []*ackv1alpha1.Condition{
+		{Type: ackv1alpha1.ConditionTypeReferencesResolved, Status: corev1.ConditionTrue},
+	}
+	desiredCopy.On("Conditions").Return(inFlight)
+	desiredCopy.On("ReplaceConditions", inFlight).Return()
 
 	rm := &ackmocks.AWSResourceManager{}
 	// Model a customUpdate that hands back the resource it was given.
@@ -2762,9 +2779,10 @@ func TestReconcilerUpdate_PassesCopyOfDesiredToUpdate(t *testing.T) {
 	// So a manager that returns its input cannot alias the patch base.
 	require.NotSame(acktypes.AWSResource(desired), updated)
 	// And the copy carries the observed status, not the last-persisted one.
+	// resourceMocks' DeepCopy returns the receiver, so the argument is `latest`.
 	desiredCopy.AssertCalled(t, "SetStatus", latest)
-	// Conditions come along with the observed status, so they are cleared to
-	// keep the runtime's condition lifecycle intact: a condition set by a
-	// ReadOne hook on `latest` must not suppress ensureConditions.
-	desiredCopy.AssertCalled(t, "ReplaceConditions", []*ackv1alpha1.Condition{})
+	// ...while keeping its own conditions rather than adopting latest's, so a
+	// condition set by a ReadOne hook cannot suppress ensureConditions and
+	// ACK.ReferencesResolved is not lost.
+	desiredCopy.AssertCalled(t, "ReplaceConditions", inFlight)
 }

--- a/pkg/runtime/reconciler_test.go
+++ b/pkg/runtime/reconciler_test.go
@@ -97,8 +97,10 @@ func resourceMocks() (
 	res.On("MetaObject").Return(metaObj)
 	res.On("RuntimeObject").Return(rtObj)
 	res.On("DeepCopy").Return(res)
-	// DoNothing on SetStatus call.
-	res.On("SetStatus", res).Return(func(res ackmocks.AWSResource) {})
+	// DoNothing on SetStatus call. Accept any argument: updateResource calls
+	// SetStatus(latest) on its copy of desired, so the argument is not always
+	// the receiver.
+	res.On("SetStatus", mock.Anything).Return()
 
 	return res, rtObj, metaObj
 }
@@ -2676,4 +2678,88 @@ func TestSecretValueFromReference_NilRef(t *testing.T) {
 	val, err := r.SecretValueFromReference(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Empty(t, val)
+}
+
+// resourceMockReturningCopy builds an AWSResource mock whose DeepCopy returns
+// the supplied distinct mock. resourceMocks stubs DeepCopy to return the
+// receiver, which cannot express "was this resource copied?".
+func resourceMockReturningCopy(cp acktypes.AWSResource) *ackmocks.AWSResource {
+	objKind := &k8srtschemamocks.ObjectKind{}
+	objKind.On("GroupVersionKind").Return(
+		k8srtschema.GroupVersionKind{
+			Group:   "bookstore.services.k8s.aws",
+			Kind:    "Book",
+			Version: "v1alpha1",
+		},
+	)
+	rtObj := &ctrlrtclientmock.Object{}
+	rtObj.On("GetObjectKind").Return(objKind)
+	rtObj.On("DeepCopyObject").Return(rtObj)
+
+	metaObj := &k8sobj.Unstructured{}
+	metaObj.SetAnnotations(map[string]string{})
+	metaObj.SetNamespace("default")
+	metaObj.SetName("mybook")
+
+	res := &ackmocks.AWSResource{}
+	res.On("MetaObject").Return(metaObj)
+	res.On("RuntimeObject").Return(rtObj)
+	res.On("DeepCopy").Return(cp)
+	return res
+}
+
+// TestReconcilerUpdate_PassesCopyOfDesiredToUpdate is a regression test for
+// status writes being silently dropped.
+//
+// ACK permits a resource manager's Update to return the object it was given,
+// and hand-written customUpdate implementations do (ecr-controller's
+// customUpdateRepository, ec2-controller's customUpdateManagedPrefixList). If
+// that object were the stored `desired`, it would also be the base of the
+// status merge patch in patchResourceStatus -- base and target would be the
+// same object, the computed patch would be `{}`, and any status the manager
+// just set would never reach the API server.
+//
+// updateResource must therefore hand Update a copy, never `desired` itself.
+func TestReconcilerUpdate_PassesCopyOfDesiredToUpdate(t *testing.T) {
+	require := require.New(t)
+	ctx := context.TODO()
+
+	delta := ackcompare.NewDelta()
+	delta.Add("Spec.A", "val1", "val2")
+
+	desiredCopy, _, _ := resourceMocks()
+	desired := resourceMockReturningCopy(desiredCopy)
+	latest, _, _ := resourceMocks()
+
+	// The copy is also given the observed status before Update sees it.
+	desiredCopy.On("SetStatus", latest).Return()
+
+	rm := &ackmocks.AWSResourceManager{}
+	// Model a customUpdate that hands back the resource it was given.
+	rm.On("Update", ctx, mock.Anything, latest, delta).Return(desiredCopy, nil)
+	rm.On("ClearResolvedReferences", mock.Anything).Return(
+		func(r acktypes.AWSResource) acktypes.AWSResource { return r },
+	)
+	rm.On("FilterSystemTags", mock.Anything, mock.Anything)
+
+	rmf, rd := managedResourceManagerFactoryMocks(desired, latest)
+	rd.On("IsManaged", latest).Return(true)
+	rd.On("Delta", mock.Anything, mock.Anything).Return(delta)
+
+	r, kc, _ := reconcilerMocks(rmf)
+	kc.On("Patch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	rr, ok := r.(*resourceReconciler)
+	require.True(ok)
+
+	updated, err := rr.updateResource(ctx, rm, desired, latest)
+	require.NoError(err)
+
+	// Update received the copy, not the stored desired.
+	rm.AssertCalled(t, "Update", ctx, desiredCopy, latest, delta)
+	rm.AssertNotCalled(t, "Update", ctx, desired, latest, delta)
+	// So a manager that returns its input cannot alias the patch base.
+	require.NotSame(acktypes.AWSResource(desired), updated)
+	// And the copy carries the observed status, not the last-persisted one.
+	desiredCopy.AssertCalled(t, "SetStatus", latest)
 }


### PR DESCRIPTION
Issue #, if available: none filed yet.

Description of changes:

`updateResource` handed the stored `desired` resource straight to `rm.Update`. ACK permits a resource manager's `Update` to return the object it was given, and hand-written `customUpdate` implementations do — ecr-controller's `customUpdateRepository` and ec2-controller's `customUpdateManagedPrefixList` both end in `return desired, nil`.

When that happens `latest` and `desired` are the same object, and that object is also the base of the status merge patch:

```go
dobj := desired.DeepCopy().RuntimeObject()   // base
lobj := latest.DeepCopy().RuntimeObject()    // target
patch := client.MergeFrom(dobj)
```

Diffing an object against itself yields `{}`, so the status write reaches the API server as a no-op and any status the manager just set — conditions, observed state — is discarded.

### Effect

A resource stuck on a stale condition. A controller that writes `ResourceSynced=False` from a `sdk_create_post_set_output` hook and relies on the update path to clear it never gets it cleared by the reconcile that performs the update. Two things compound: the status patch is `{}`, so etcd keeps `False`; and the in-memory condition *is* `True`, so `handleRequeues` takes the synced branch and requeues after `resyncPeriod` instead of the 30s `TemporaryOutOfSync` delay.

Measured on a live cluster with eventbridge-controller at the commit from aws-controllers-k8s/eventbridge-controller#102 that precedes its own controller-side fix, so both arms ran identical controller code and the runtime was the only variable. 60s resync, `EventBus` created with `spec.policy`:

| runtime | policy live in AWS | CR `Synced=True` | stale window |
|---|---|---|---|
| released v0.62.0 | t+33s | t+90s | 63s (one resync period) |
| this change | t+33s | t+33s | 0s |

At the chart default `reconcile.defaultResyncPeriod: 36000` that window is up to 10 hours, during which anything gating on `Ready` sees an unhealthy resource while AWS is fully configured.

ecr-controller has both halves on `main` today: its create hook writes `Synced=False` when `spec.policy` or `spec.lifecyclePolicy` is set, and `customUpdateRepository` returns `desired` uncopied.

Observed state is dropped the same way. ec2-controller's `customUpdateManagedPrefixList` sets `Status.State` and `Status.Version` from the `ModifyManagedPrefixList` response and then returns `desired`, so neither write reaches etcd.

### Fix

Two changes, both in `updateResource`:

1. **Deep-copy `desired` before handing it to `Update`**, so a manager that returns what it was given cannot alias the patch base. This generalizes the precedent immediately below it — the ignore-field-drift path already replaces `reconcileDesired` with a merged copy, and so already avoids this aliasing whenever that gate is enabled.

2. **Apply the observed status to that copy, keeping the copy's own conditions.** `desired` carries the status last persisted to etcd, while `latest` carries what the service reports now; an `Update` should reason about observed state. This runs after the ignore-field-drift branch, which replaces the copy with one derived from `desired` and would otherwise discard it.

`AWSResource.SetStatus` cannot express change 2 on its own. `Status` holds both service-reported state and ACK's conditions, and `SetStatus` replaces the whole struct, so it cannot adopt observed state without also adopting `latest`'s conditions. A `setStatusWithoutConditions` helper withholds them, because neither side's conditions belong on the copy:

- Adopting `latest`'s would suppress recomputation. `resetConditions` clears conditions each reconcile so `ensureConditions` can rebuild them, and `ensureConditions` only runs while `Synced` is nil — a `ReadOne` hook that marks a resource not-yet-synced would stick. ec2-controller's `VPCEndpoint` does exactly this while an endpoint is pending.
- Dropping the copy's own would lose conditions set after `resetConditions`, notably `ACK.ReferencesResolved`.

The result is what the released runtime already gives `Update` condition-wise, plus the observed non-condition status.

Scoped to the `Update` call site rather than to the patch base, which keeps `desired` as the base, leaves steady-state write behaviour unchanged for every controller, and requires no new exported API. Generated `sdkUpdate` implementations are unaffected either way — they already return `&resource{ko}` built from `desired.ko.DeepCopy()`.

### Prerequisite

aws-controllers-k8s/ec2-controller#368 — merged.

Before that landed, `ec2-controller-test` failed on `test_managed_prefix_list.py::test_update_entries` and `::test_update_tags`. Both were true positives this change exposed rather than caused.

`ManagedPrefixList` compared `Spec.Entries` with an order-sensitive `DeepEqual` while `GetManagedPrefixListEntries` returns them in an order AWS chooses, so the delta never cleared. `customUpdateManagedPrefixList` re-issued `ModifyManagedPrefixList` carrying `CurrentVersion` with no entry modification on every reconcile, which AWS rejects with `InvalidParameterCombination`. That loop was present with or without this change, since the delta and the request are identical either way. What this change altered is only whether the CR reported it: `customUpdateManagedPrefixList` ended in `return desired, nil`, so on the released runtime the returned object was also the status merge-patch base, the patch was `{}`, and the CR kept the stale `Synced=True` from creation — which the test's `wait_on_condition(..., "True")` matched.

Confirmed on a live cluster: with this change and an unfixed ec2-controller, the CR sat at `Synced=Unknown` with reason `InvalidParameterCombination` for 40 polls while AWS reported `modify-complete` with all four entries. With #368 applied it reached `Synced=True` in ~35s and held it across a resync period. Same job and same tests for comparison: build `2084372351612358656` on #263 (released runtime) passed both, build `2092394037469253632` here failed both.

### Known impact

Change 2 alters what an `Update` observes in `desired.Status`, from the last-persisted status to the observed one. One resource in the fleet depends on the difference between the two: quicksight-controller's `Dashboard` compares `a.ko.Status.VersionNumber` against `b.ko.Status.VersionNumber` in its `delta_post_compare` hook, and `sdkUpdate` uses that delta to decide whether to publish a draft dashboard version.

With the observed status applied, the two sides are equal, the delta no longer fires, and `UpdateDashboardPublishedVersion` is never called — a dashboard would get a new draft version that is never published. Confirmed against `newResourceDelta` directly: modelling draft version 2 with published version 1, `DifferentAt("Status.VersionNumber")` is `true` before and `false` after.

No other controller reads the first delta argument's status or branches on a `Status.*` difference. A follow-up will move Dashboard's publish decision onto observed state (`ListDashboardVersions` against the published version) so it no longer relies on persisted status.

### Testing

`TestReconcilerUpdate_PassesCopyOfDesiredToUpdate` models a `customUpdate` that hands back the resource it was given. It asserts `Update` received a copy rather than the stored `desired`, that the copy was given the observed status, and that the copy kept its own conditions rather than adopting `latest`'s. It fails when either change is removed.

`resourceMocks` accepts any `SetStatus` argument, since that argument is no longer always the receiver, and tests reaching the update path stub `Conditions`.

`go build ./...` clean, `go test ./...` passes (10 packages), `gofmt` clean. `go vet ./pkg/runtime/` reports only warnings pre-existing on `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


