### PR TITLE
fix: adding a new `IAMRoleSelected` condition should check for existing `IAMRoleSelected` condition types

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -293,7 +293,7 @@ func SetIAMRoleSelected(
 ) {
 	allConds := subject.Conditions()
 	var c *ackv1alpha1.Condition
-	if c = ReferencesResolved(subject); c == nil {
+	if c = IAMRoleSelected(subject); c == nil {
 		c = &ackv1alpha1.Condition{
 			Type: ackv1alpha1.ConditionTypeIAMRoleSelected,
 		}

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/utils/ptr"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcond "github.com/aws-controllers-k8s/runtime/pkg/condition"
@@ -348,7 +349,8 @@ func TestConditionSetters(t *testing.T) {
 	)
 	ackcond.SetReady(r, corev1.ConditionTrue, nil, nil)
 
-	// IAMRoleSelected condition
+	// IAMRoleSelected condition - a list of Conditions with nothing matching IAMRoleSelected should add
+	// a new Condition.
 	r = &ackmocks.AWSResource{}
 	r.On("Conditions").Return([]*ackv1alpha1.Condition{})
 	r.On(
@@ -362,4 +364,28 @@ func TestConditionSetters(t *testing.T) {
 		}),
 	)
 	ackcond.SetIAMRoleSelected(r, corev1.ConditionTrue, nil, nil)
+
+	// IAMRoleSelected condition - a list of Conditions with IAMRoleSelected already in it must be replaced
+	// instead of adding one more.
+	r = &ackmocks.AWSResource{}
+	r.On("Conditions").Return([]*ackv1alpha1.Condition{
+		{
+			Type:    ackv1alpha1.ConditionTypeIAMRoleSelected,
+			Status:  corev1.ConditionFalse,
+			Message: ptr.To("this is the original"),
+		},
+	})
+	replacementMsg := "this is the replacement"
+	r.On(
+		"ReplaceConditions",
+		mock.MatchedBy(func(subject []*ackv1alpha1.Condition) bool {
+			if len(subject) != 1 {
+				return false
+			}
+			return (subject[0].Type == ackv1alpha1.ConditionTypeIAMRoleSelected &&
+				subject[0].Status == corev1.ConditionTrue &&
+				*subject[0].Message == replacementMsg)
+		}),
+	)
+	ackcond.SetIAMRoleSelected(r, corev1.ConditionTrue, &replacementMsg, nil)
 }


### PR DESCRIPTION
The IAMRoleSelected condition setter was matching erroneously on the `ReferencesResolved` condition to find existing conditions, which would produce a result like:
```
    conditions:
    - lastTransitionTime: "2026-08-25T13:39:44Z"
      message: Late initialization successful
      reason: Late initialization successful
      status: "True"
      type: ACK.LateInitialized
    - lastTransitionTime: "2026-08-25T13:39:44Z"
      message: Resource synced successfully
      reason: ""
      status: "True"
      type: ACK.ResourceSynced
    - lastTransitionTime: "2026-08-25T13:39:44Z"
      message: Resource synced successfully
      reason: ""
      status: "True"
      type: Ready
    - lastTransitionTime: "2026-08-25T13:39:44Z"
      message: Selected
      reason: 'roleARN: arn:aws:iam::929690601429:role/ack-ec2-controller-cell, selectorName:
        ack-ec2-sre-2, selectorResourceVersion: 120442'
      status: "True"
      type: ACK.IAMRoleSelected
    - message: 'api error DependencyViolation: The vpc ''vpc-0a3ee9e1212075d03'' has
        dependencies and cannot be deleted.'
      status: "True"
      type: ACK.Recoverable
    - lastTransitionTime: "2026-08-26T00:19:50Z"
      message: Selected
      reason: 'roleARN: arn:aws:iam::929690601429:role/ack-ec2-controller-cell, selectorName:
        ack-ec2-sre-2, selectorResourceVersion: 120442'
      status: "True"
      type: ACK.IAMRoleSelected
    - lastTransitionTime: "2026-08-26T00:19:52Z"
      message: Selected
      reason: 'roleARN: arn:aws:iam::929690601429:role/ack-ec2-controller-cell, selectorName:
        ack-ec2-sre-2, selectorResourceVersion: 120442'
      status: "True"
      type: ACK.IAMRoleSelected
    - lastTransitionTime: "2026-08-26T00:19:54Z"
      message: Selected
      reason: 'roleARN: arn:aws:iam::929690601429:role/ack-ec2-controller-cell, selectorName:
        ack-ec2-sre-2, selectorResourceVersion: 120442'
      status: "True"
      type: ACK.IAMRoleSelected
    - lastTransitionTime: "2026-08-26T00:19:57Z"
      message: Selected
      reason: 'roleARN: arn:aws:iam::929690601429:role/ack-ec2-controller-cell, selectorName:
        ack-ec2-sre-2, selectorResourceVersion: 120442'
      status: "True"
... keeps going ...
```

for a VPC resource (or any other resource that has no references to resolve). Not sure if I should also add in logic to remove extra condition types there might be of the same type - though that should probably generally apply to all condition types.